### PR TITLE
fix: return non-zero exit code upon error

### DIFF
--- a/cmd/ctl/os/download.go
+++ b/cmd/ctl/os/download.go
@@ -34,7 +34,7 @@ func NewCmdDownload() *cobra.Command {
 			helper.InitLog(o.BaseDir)
 
 			if err := pipelines.DownloadInstallationPackage(o); err != nil {
-				logger.Errorf("download terminus installation package error: %v", err)
+				logger.Fatalf("download terminus installation package error: %v", err)
 			}
 		},
 	}


### PR DESCRIPTION
the current `Errorf` only prints the error, but a zero exit code is still returned, resulting the `install.sh` to continue executing regardless of the error.