### PR TITLE
fix: do not start kubelet if juicefs is not mounted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@
 go.work
 go.work.sum
 
+# IDE files
+.idea/
+
 frontend/dist/
 frontend/node_modules/
 

--- a/pkg/k3s/tasks.go
+++ b/pkg/k3s/tasks.go
@@ -17,6 +17,8 @@
 package k3s
 
 import (
+	"bytetrade.io/web3os/installer/pkg/storage"
+	storagetpl "bytetrade.io/web3os/installer/pkg/storage/templates"
 	"context"
 	"encoding/base64"
 	"fmt"
@@ -217,21 +219,24 @@ func (g *GenerateK3sService) Execute(runtime connector.Runtime) error {
 	kubeProxyArgs, _ := util.GetArgs(defaultKubeProxyArgs, g.KubeConf.Cluster.Kubernetes.KubeProxyArgs)
 
 	var data = util.Data{
-		"Server":            server,
-		"IsMaster":          host.IsRole(common.Master),
-		"NodeIP":            host.GetInternalAddress(),
-		"HostName":          host.GetName(),
-		"PodSubnet":         g.KubeConf.Cluster.Network.KubePodsCIDR,
-		"ServiceSubnet":     g.KubeConf.Cluster.Network.KubeServiceCIDR,
-		"ClusterDns":        g.KubeConf.Cluster.CorednsClusterIP(),
-		"CertSANs":          g.KubeConf.Cluster.GenerateCertSANs(),
-		"PauseImage":        images.GetImage(runtime, g.KubeConf, "pause").ImageName(),
-		"Container":         fmt.Sprintf("unix://%s", container.DefaultContainerdCRISocket),
-		"ApiserverArgs":     kubeApiserverArgs,
-		"ControllerManager": kubeControllerManager,
-		"SchedulerArgs":     kubeSchedulerArgs,
-		"KubeletArgs":       kubeletArgs,
-		"KubeProxyArgs":     kubeProxyArgs,
+		"Server":             server,
+		"IsMaster":           host.IsRole(common.Master),
+		"NodeIP":             host.GetInternalAddress(),
+		"HostName":           host.GetName(),
+		"PodSubnet":          g.KubeConf.Cluster.Network.KubePodsCIDR,
+		"ServiceSubnet":      g.KubeConf.Cluster.Network.KubeServiceCIDR,
+		"ClusterDns":         g.KubeConf.Cluster.CorednsClusterIP(),
+		"CertSANs":           g.KubeConf.Cluster.GenerateCertSANs(),
+		"PauseImage":         images.GetImage(runtime, g.KubeConf, "pause").ImageName(),
+		"Container":          fmt.Sprintf("unix://%s", container.DefaultContainerdCRISocket),
+		"ApiserverArgs":      kubeApiserverArgs,
+		"ControllerManager":  kubeControllerManager,
+		"SchedulerArgs":      kubeSchedulerArgs,
+		"KubeletArgs":        kubeletArgs,
+		"KubeProxyArgs":      kubeProxyArgs,
+		"JuiceFSServiceUnit": storagetpl.JuicefsService.Name(),
+		"JuiceFSBinPath":     storage.JuiceFsFile,
+		"JuiceFSMountPoint":  storage.JuiceFsMountPointDir,
 	}
 
 	templateAction := action.Template{

--- a/pkg/k3s/templates/k3sService.go
+++ b/pkg/k3s/templates/k3sService.go
@@ -30,6 +30,7 @@ Description=Lightweight Kubernetes
 Documentation=https://k3s.io
 Wants=network-online.target
 After=network-online.target
+After={{ .JuiceFSServiceUnit }}
 
 [Install]
 WantedBy=multi-user.target
@@ -54,6 +55,7 @@ Restart=always
 RestartSec=5s
 ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=-/sbin/modprobe overlay
+ExecStartPre={{ .JuiceFSBinPath }} summary {{ .JuiceFSMountPoint }}
 ExecStart=/usr/local/bin/k3s $K3S_ROLE $K3S_ARGS $K3S_EXTRA_ARGS $K3S_SERVER_ARGS
     `)))
 

--- a/pkg/kubernetes/module.go
+++ b/pkg/kubernetes/module.go
@@ -17,6 +17,9 @@
 package kubernetes
 
 import (
+	"bytetrade.io/web3os/installer/pkg/core/util"
+	"bytetrade.io/web3os/installer/pkg/storage"
+	storagetpl "bytetrade.io/web3os/installer/pkg/storage/templates"
 	"fmt"
 	"path/filepath"
 	"time"
@@ -97,6 +100,11 @@ func (i *InstallKubeBinariesModule) Init() {
 			Name:     "GenerateKubeletService",
 			Template: templates.KubeletService,
 			Dst:      filepath.Join("/etc/systemd/system/", templates.KubeletService.Name()),
+			Data: util.Data{
+				"JuiceFSServiceUnit": storagetpl.JuicefsService.Name(),
+				"JuiceFSBinPath":     storage.JuiceFsFile,
+				"JuiceFSMountPoint":  storage.JuiceFsMountPointDir,
+			},
 		},
 		Parallel: true,
 		Retry:    2,

--- a/pkg/kubernetes/templates/kubelet_service.go
+++ b/pkg/kubernetes/templates/kubelet_service.go
@@ -27,10 +27,12 @@ var KubeletService = template.Must(template.New("kubelet.service").Parse(
 	dedent.Dedent(`[Unit]
 Description=kubelet: The Kubernetes Node Agent
 Documentation=http://kubernetes.io/docs/
+After={{ .JuiceFSServiceUnit }}
 
 [Service]
 CPUAccounting=true
 MemoryAccounting=true
+ExecStartPre={{ .JuiceFSBinPath }} summary {{ .JuiceFSMountPoint }}
 ExecStart=/usr/local/bin/kubelet
 Restart=always
 StartLimitInterval=0

--- a/pkg/storage/constants.go
+++ b/pkg/storage/constants.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"bytetrade.io/web3os/installer/pkg/storage/templates"
 	"path"
 
 	"bytetrade.io/web3os/installer/pkg/core/common"
@@ -28,7 +29,7 @@ var (
 	JuiceFsDataDir       = path.Join(Root, cc.TerminusDir, "data", "juicefs")
 	JuiceFsCacheDir      = path.Join(Root, cc.TerminusDir, "jfscache")
 	JuiceFsMountPointDir = path.Join(Root, cc.TerminusDir, "rootfs")
-	JuiceFsServiceFile   = path.Join(Root, "etc", "systemd", "system", "juicefs.service")
+	JuiceFsServiceFile   = path.Join(Root, "etc", "systemd", "system", templates.JuicefsService.Name())
 
 	MinioRootUser    = "minioadmin"
 	MinioDataDir     = path.Join(Root, cc.TerminusDir, "data", "minio", "vol1")


### PR DESCRIPTION
If for some reasons the rootfs of Terminus is not mounted by JuiceFS, for example if the Redis or MinIO service is down, or juiceFS inits with a config pointing to the wrong storage backend,

and the kubelet still starts and runs pods regardlessly,

the I/Os done by the pods are on the local FS of the host machine, instead of to JuiceFS,

which messes up app data, e.g. cookie sessions stored in Redis or data of Files will be lost

this case can be avoided by always checking the rootfs is mounted before starting kubelet, 

by simply add a `ExecStartPre=juicefs summary {rootfs mount path}` in the service file of k3s and kubelet

if the rootfs is not mounted, the command exits 1 and the starting of kubelet is retried by systems