### PR TITLE
fix: add backward logging compatibility for cloud provisioning

### DIFF
--- a/pkg/bootstrap/download/module.go
+++ b/pkg/bootstrap/download/module.go
@@ -2,6 +2,7 @@ package download
 
 import (
 	"bytetrade.io/web3os/installer/pkg/common"
+	"bytetrade.io/web3os/installer/pkg/core/logger"
 	"bytetrade.io/web3os/installer/pkg/core/task"
 )
 
@@ -12,6 +13,7 @@ type PackageDownloadModule struct {
 }
 
 func (i *PackageDownloadModule) Init() {
+	logger.InfoInstallationProgress("downloading terminus installation packages ...")
 	i.Name = "PackageDownloadModule"
 	i.Desc = "Download terminus installation package"
 

--- a/pkg/bootstrap/patch/module.go
+++ b/pkg/bootstrap/patch/module.go
@@ -2,6 +2,7 @@ package patch
 
 import (
 	"bytetrade.io/web3os/installer/pkg/common"
+	"bytetrade.io/web3os/installer/pkg/core/logger"
 	"bytetrade.io/web3os/installer/pkg/core/task"
 	"bytetrade.io/web3os/installer/pkg/manifest"
 )
@@ -12,6 +13,7 @@ type InstallDepsModule struct {
 }
 
 func (m *InstallDepsModule) Init() {
+	logger.InfoInstallationProgress("installing and configuring OS dependencies ...")
 	m.Name = "InstallDeps"
 
 	patchOs := &task.RemoteTask{

--- a/pkg/core/connector/runtime.go
+++ b/pkg/core/connector/runtime.go
@@ -230,7 +230,9 @@ func (b *BaseRuntime) HostIsDeprecated(host Host) bool {
 }
 
 func (b *BaseRuntime) InitLogger() error {
-	logger.InitLog(path.Join(b.baseDir, "logs"))
+	// the JSON-structured logs under .terminus/logs/yyyy-mm-dd_hh-mm-ss.log
+	// and the console formatted logs under .terminus/versions/v{version}/install.log (for backward compatibility)
+	logger.InitLog(path.Join(b.baseDir, "logs"), path.Join(b.installerDir, "logs"))
 	return nil
 }
 

--- a/pkg/images/module.go
+++ b/pkg/images/module.go
@@ -18,6 +18,7 @@ package images
 
 import (
 	"bytetrade.io/web3os/installer/pkg/common"
+	"bytetrade.io/web3os/installer/pkg/core/logger"
 	"bytetrade.io/web3os/installer/pkg/core/prepare"
 	"bytetrade.io/web3os/installer/pkg/core/task"
 	"bytetrade.io/web3os/installer/pkg/kubesphere/plugins"
@@ -35,6 +36,7 @@ func (p *PreloadImagesModule) IsSkip() bool {
 }
 
 func (p *PreloadImagesModule) Init() {
+	logger.InfoInstallationProgress("preloading terminus container images ...")
 	p.Name = "PreloadImages"
 
 	preload := &task.RemoteTask{

--- a/pkg/terminus/account.go
+++ b/pkg/terminus/account.go
@@ -98,6 +98,7 @@ func (s *GetUserInfo) getUserName() (string, error) {
 		if err := utils.ValidateUserName(userName); err != nil {
 			return "", fmt.Errorf("invalid username \"%s\" set in env: %s, please reset", userName, err.Error())
 		}
+		return userName, nil
 	}
 
 	reader := bufio.NewReader(os.Stdin)


### PR DESCRIPTION
tee the console installation log to the `.terminus/versions/v{VERSION}/logs/install.log` for backward compatibility and add more [INFO] and [FATAL] logs for cloud provisioning scenario