### PR TITLE
fix: support auto-selecting unspecified local interface IP

### DIFF
--- a/pkg/bootstrap/precheck/tasks.go
+++ b/pkg/bootstrap/precheck/tasks.go
@@ -61,7 +61,7 @@ func (t *CorrectHostname) Execute(runtime connector.Runtime) error {
 		return nil
 	}
 	hostname := strings.ToLower(hostName)
-	if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("hostnamectl set-hostname %s", hostname), false, true); err != nil {
+	if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("hostnamectl set-hostname %s", hostname), false, false); err != nil {
 		return err
 	}
 	runtime.GetSystemInfo().SetHostname(hostname)

--- a/pkg/core/connector/system.go
+++ b/pkg/core/connector/system.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/pkg/errors"
 	"net"
 	"os"
 	"os/exec"
@@ -291,7 +292,12 @@ func GetSystemInfo() *SystemInfo {
 	si.DiskInfo = getDisk()
 	si.MemoryInfo = getMem()
 	si.FsInfo = getFs()
-	si.LocalIp = util.GetLocalIP()
+
+	localIP, err := util.GetLocalIP()
+	if err != nil {
+		panic(errors.Wrap(err, "failed to get local ip"))
+	}
+	si.LocalIp = localIP.String()
 
 	if si.IsLinux() {
 		si.CgroupInfo = getCGroups()

--- a/pkg/storage/redis.go
+++ b/pkg/storage/redis.go
@@ -56,14 +56,6 @@ func (t *EnableRedisService) Execute(runtime connector.Runtime) error {
 		return err
 	}
 
-	cmd = fmt.Sprintf("awk '/requirepass/{print \\$NF}' %s", RedisConfigFile)
-	rpwd, _ := runtime.GetRunner().Host.SudoCmd(cmd, false, false)
-	if rpwd == "" {
-		return fmt.Errorf("get redis password failed")
-	}
-
-	t.PipelineCache.Set(common.CacheHostRedisPassword, rpwd)
-
 	return nil
 }
 


### PR DESCRIPTION
select local IP address by the following priority:
- env var `OS_LOCALIP`
- lookup hostname
- local network interface's address

only exit with error when no valid IP address can be found