### PR TITLE
fix: lift the retry limit on all systemd units

### DIFF
--- a/pkg/bootstrap/registry/templates/harbor.go
+++ b/pkg/bootstrap/registry/templates/harbor.go
@@ -26,6 +26,7 @@ var (
 Description=Harbor
 After=docker.service systemd-networkd.service systemd-resolved.service
 Requires=docker.service
+StartLimitIntervalSec=0
 
 [Service]
 Type=simple

--- a/pkg/bootstrap/registry/templates/registry.go
+++ b/pkg/bootstrap/registry/templates/registry.go
@@ -25,6 +25,7 @@ var (
 		dedent.Dedent(`[Unit]
 Description=v2 Registry server for Container
 After=network.target
+StartLimitIntervalSec=0
 [Service]
 Type=simple
 ExecStart=/usr/local/bin/registry serve /etc/kubekey/registry/config.yaml

--- a/pkg/certs/templates/certs_renew_service.go
+++ b/pkg/certs/templates/certs_renew_service.go
@@ -27,6 +27,7 @@ var (
 	K8sCertsRenewService = template.Must(template.New("k8s-certs-renew.service").Parse(
 		dedent.Dedent(`[Unit]
 Description=Renew K8S control plane certificates
+StartLimitIntervalSec=0
 [Service]
 Type=oneshot
 ExecStart=/usr/local/bin/kube-scripts/k8s-certs-renew.sh

--- a/pkg/container/templates/containerd_service.go
+++ b/pkg/container/templates/containerd_service.go
@@ -27,6 +27,7 @@ var ContainerdService = template.Must(template.New("containerd.service").Parse(
 Description=containerd container runtime
 Documentation=https://containerd.io
 After=network.target local-fs.target
+StartLimitIntervalSec=0
 
 [Service]
 ExecStartPre=-/sbin/modprobe overlay

--- a/pkg/container/templates/docker_service.go
+++ b/pkg/container/templates/docker_service.go
@@ -29,6 +29,7 @@ Documentation=https://docs.docker.com
 # After=network-online.target firewalld.service containerd.service
 # Wants=network-online.target
 # Requires=docker.socket containerd.service
+StartLimitIntervalSec=0
 
 [Service]
 Type=notify

--- a/pkg/daemon/templates/terminusd_service.go
+++ b/pkg/daemon/templates/terminusd_service.go
@@ -12,6 +12,7 @@ var (
 		dedent.Dedent(`[Unit]
 Description=terminusd
 After=network.target
+StartLimitIntervalSec=0
 
 [Service]
 User=root

--- a/pkg/etcd/templates/backup_service.go
+++ b/pkg/etcd/templates/backup_service.go
@@ -38,6 +38,7 @@ ExecStart={{ .ScriptPath }}
 	BackupETCDTimer = template.Must(template.New("backup-etcd.timer").Parse(
 		dedent.Dedent(`[Unit]
 Description=Timer to backup ETCD
+StartLimitIntervalSec=0
 [Timer]
 {{- if .OnCalendarStr }}
 OnCalendar={{ .OnCalendarStr }}

--- a/pkg/etcd/templates/etcd_service.go
+++ b/pkg/etcd/templates/etcd_service.go
@@ -28,6 +28,7 @@ var (
 		dedent.Dedent(`[Unit]
 Description=etcd
 After=network.target
+StartLimitIntervalSec=0
 
 [Service]
 User=root

--- a/pkg/k3s/templates/k3sService.go
+++ b/pkg/k3s/templates/k3sService.go
@@ -30,6 +30,7 @@ Description=Lightweight Kubernetes
 Documentation=https://k3s.io
 Wants=network-online.target
 After=network-online.target
+StartLimitIntervalSec=0
 {{ if .JuiceFSPreCheckEnabled }}
 After={{ .JuiceFSServiceUnit }}
 {{ end }}

--- a/pkg/kubernetes/templates/kubelet_service.go
+++ b/pkg/kubernetes/templates/kubelet_service.go
@@ -30,6 +30,7 @@ Documentation=http://kubernetes.io/docs/
 {{ if .JuiceFSPreCheckEnabled }}
 After={{ .JuiceFSServiceUnit }}
 {{ end }}
+StartLimitIntervalSec=0
 
 [Service]
 CPUAccounting=true

--- a/pkg/storage/templates/juicefs.go
+++ b/pkg/storage/templates/juicefs.go
@@ -13,6 +13,7 @@ Documentation=https://juicefs.com/docs/zh/community/introduction/
 Wants=redis-online.target
 After=redis-online.target
 AssertFileIsExecutable={{ .JuiceFsBinPath }}
+StartLimitIntervalSec=0
 
 [Service]
 WorkingDirectory=/usr/local

--- a/pkg/storage/templates/minio.go
+++ b/pkg/storage/templates/minio.go
@@ -13,6 +13,7 @@ Documentation=https://min.io/docs/minio/linux/index.html
 Wants=network-online.target
 After=network-online.target
 AssertFileIsExecutable={{ .MinioCommand }}
+StartLimitIntervalSec=0
 
 [Service]
 WorkingDirectory=/usr/local

--- a/pkg/storage/templates/redis.go
+++ b/pkg/storage/templates/redis.go
@@ -39,6 +39,7 @@ Documentation=https://redis.io/
 Wants=network-online.target
 After=network-online.target
 AssertFileIsExecutable={{ .RedisBinPath }}
+StartLimitIntervalSec=0
 
 [Service]
 WorkingDirectory={{ .RootPath }}


### PR DESCRIPTION
As per the official doc of systemd: https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#StartLimitIntervalSec=interval

> Configure unit start rate limiting. Units which are started more than burst times within an interval time span are **not permitted to start any more**. Use StartLimitIntervalSec= to configure the checking interval and StartLimitBurst= to configure how many starts per interval are allowed.

the current service unit files we create will stop retrying once they reach the burst limit, which is not an expected behaviour 