### PR TITLE
fix: use helm templating instead of sed replace

### DIFF
--- a/pkg/terminus/templates/settings.go
+++ b/pkg/terminus/templates/settings.go
@@ -15,6 +15,8 @@ cluster_id: {{ .ClusterID }}
 s3_sts: {{ .S3SessionToken }}
 s3_ak: {{ .S3AccessKey }}
 s3_sk: {{ .S3SecretKey }}
+domainName: '{{ .DomainName }}'
+selfHosted: '{{ .SelfHosted }}'
 terminusd: '{{ .TerminusdInstalled }}'
 
 user:


### PR DESCRIPTION
the legacy way of filling placeholder strings in yaml files (notably the `terminus_cr.yaml`) before installing it by helm may cause a problem that, if the OS is uninstalled and then installed again, the modified yaml files will remain the same and the replace operation in the new installation process will not take any effect, resulting in in consistent behaviors. 