### PR TITLE
feat: add command to build local release of Olares

### DIFF
--- a/cmd/ctl/os/release.go
+++ b/cmd/ctl/os/release.go
@@ -1,0 +1,83 @@
+package os
+
+import (
+	"bytetrade.io/web3os/installer/pkg/core/common"
+	"bytetrade.io/web3os/installer/pkg/core/util"
+	"bytetrade.io/web3os/installer/pkg/release/builder"
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+func NewCmdRelease() *cobra.Command {
+	var (
+		baseDir             string
+		version             string
+		cdn                 string
+		ignoreMissingImages bool
+		extract             bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "release",
+		Short: "Build release based on a local Olares repository",
+		Run: func(cmd *cobra.Command, args []string) {
+			cwd, err := os.Getwd()
+			if err != nil {
+				fmt.Printf("failed to get current working directory: %s\n", err)
+				os.Exit(1)
+			}
+			if filepath.Base(cwd) != "Olares" {
+				fmt.Println("error: please run release command under the root path of Olares repo")
+				os.Exit(1)
+			}
+			if baseDir == "" {
+				usr, err := user.Current()
+				if err != nil {
+					fmt.Printf("failed to get current user: %s\n", err)
+					os.Exit(1)
+				}
+				baseDir = filepath.Join(usr.HomeDir, common.DefaultBaseDir)
+				fmt.Printf("--base-dir unspecified, using: %s\n", baseDir)
+				time.Sleep(1 * time.Second)
+			}
+
+			if version == "" {
+				version = fmt.Sprintf("0.0.0-local-dev-%s", time.Now().Format("20060102150405"))
+				fmt.Printf("--version unspecified, using: %s\n", version)
+				time.Sleep(1 * time.Second)
+			}
+
+			wizardFile, err := builder.NewBuilder(cwd, version, cdn, ignoreMissingImages).Build()
+			if err != nil {
+				fmt.Printf("failed to build release: %s\n", err)
+				os.Exit(1)
+			}
+			fmt.Printf("\nsuccessfully built release\nversion: %s\n package: %s\n", version, wizardFile)
+			if extract {
+				dest := filepath.Join(baseDir, "versions", "v"+version)
+				if err := os.MkdirAll(dest, 0755); err != nil {
+					fmt.Printf("Failed to create new version directory for this release: %s\n", err)
+					os.Exit(1)
+				}
+				if err := util.Untar(wizardFile, dest); err != nil {
+					fmt.Printf("failed to extract release package: %s\n", err)
+					os.Exit(1)
+				}
+				fmt.Printf("\nrelease package is extracted to: %s\n", dest)
+			}
+		},
+	}
+
+	cmd.Flags().StringVarP(&baseDir, "base-dir", "b", "", "base directory of Olares, where this release will be extracted to as a new version if --extract/-e is not disabled, defaults to $HOME/"+common.DefaultBaseDir)
+	cmd.Flags().StringVarP(&version, "version", "v", "", "version of this release, defaults to 0.0.0-local-dev-{yyyymmddhhmmss}")
+	cmd.Flags().StringVar(&cdn, "download-cdn-url", common.DownloadUrl, "CDN used for downloading checksums of dependencies and images")
+	cmd.Flags().BoolVar(&ignoreMissingImages, "ignore-missing-images", true, "ignore missing images when downloading cheksums from CDN, only disable this if no new image is added, or the build may fail because the image is not uploaded to the CDN yet")
+	cmd.Flags().BoolVarP(&extract, "extract", "e", true, "extract this release to --base-dir after build, this can be disabled if only the release file itself is needed")
+
+	return cmd
+}

--- a/cmd/ctl/os/root.go
+++ b/cmd/ctl/os/root.go
@@ -20,6 +20,7 @@ func NewCmdOs() *cobra.Command {
 	rootOsCmd.AddCommand(NewCmdInstallOs())
 	rootOsCmd.AddCommand(NewCmdUninstallOs())
 	rootOsCmd.AddCommand(NewCmdChangeIP())
+	rootOsCmd.AddCommand(NewCmdRelease())
 	rootOsCmd.AddCommand(NewCmdPrintInfo())
 
 	return rootOsCmd

--- a/pkg/bootstrap/os/tasks.go
+++ b/pkg/bootstrap/os/tasks.go
@@ -408,7 +408,7 @@ func (a *BackupFilesToDir) Execute(runtime connector.Runtime) error {
 			return errors.Wrapf(err, "failed to create backup dir %s for file %s", path.Dir(file), path.Base(file))
 		}
 		logger.Debugf("copying file %s to backup dir %s", file, a.BackupDir)
-		if err := util.CopyFile(file, path.Join(a.BackupDir, path.Dir(file))); err != nil {
+		if err := util.CopyFile(file, path.Join(a.BackupDir, file)); err != nil {
 			return errors.Wrapf(err, "failed to copy file %s to backup dir", file)
 		}
 	}

--- a/pkg/release/app/app.go
+++ b/pkg/release/app/app.go
@@ -1,0 +1,108 @@
+package app
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"bytetrade.io/web3os/installer/pkg/core/util"
+)
+
+type Manager struct {
+	olaresRepoRoot string
+	distPath       string
+}
+
+func NewManager(olaresRepoRoot, distPath string) *Manager {
+	return &Manager{
+		olaresRepoRoot: olaresRepoRoot,
+		distPath:       distPath,
+	}
+}
+
+func (m *Manager) Package() error {
+	modules := []string{"frameworks", "libs", "apps", "third-party"}
+	buildTemplate := "build/installer"
+
+	// Create dist directory if not exists
+	if err := os.MkdirAll(m.distPath, 0755); err != nil {
+		return err
+	}
+
+	// Copy template files
+	if err := util.CopyDirectory(buildTemplate, m.distPath); err != nil {
+		return err
+	}
+
+	// Package modules
+	for _, mod := range modules {
+		if err := m.packageModule(mod); err != nil {
+			return err
+		}
+	}
+
+	// Package launcher and GPU
+	if err := m.packageLauncher(); err != nil {
+		return err
+	}
+
+	if err := m.packageGPU(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Manager) packageModule(mod string) error {
+	modPath := filepath.Join(m.olaresRepoRoot, mod)
+	entries, err := os.ReadDir(modPath)
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		app := entry.Name()
+
+		fmt.Printf("packaging %s ... \n", app)
+
+		// Package user app charts
+		chartPath := filepath.Join(modPath, app, "config/user/helm-charts")
+		if err := util.CopyDirectoryIfExists(chartPath, filepath.Join(m.distPath, "wizard/config/apps")); err != nil {
+			return err
+		}
+
+		// Package cluster CRDs
+		crdPath := filepath.Join(modPath, app, "config/cluster/crds")
+		if err := util.CopyDirectoryIfExists(crdPath, filepath.Join(m.distPath, "wizard/config/settings/templates/crds")); err != nil {
+			return err
+		}
+
+		// Package cluster deployments
+		deployPath := filepath.Join(modPath, app, "config/cluster/deploy")
+		if err := util.CopyDirectoryIfExists(deployPath, filepath.Join(m.distPath, "wizard/config/system/templates/deploy")); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *Manager) packageLauncher() error {
+	fmt.Println("packaging launcher ...")
+	return util.CopyDirectory(
+		filepath.Join(m.olaresRepoRoot, "frameworks/bfl/config/launcher"),
+		filepath.Join(m.distPath, "wizard/config/launcher"),
+	)
+}
+
+func (m *Manager) packageGPU() error {
+	fmt.Println("packaging gpu ...")
+	return util.CopyDirectory(
+		filepath.Join(m.olaresRepoRoot, "frameworks/GPU/config/gpu"),
+		filepath.Join(m.distPath, "wizard/config/gpu"),
+	)
+}

--- a/pkg/release/builder/builder.go
+++ b/pkg/release/builder/builder.go
@@ -1,0 +1,92 @@
+package builder
+
+import (
+	"bytetrade.io/web3os/installer/pkg/core/util"
+	"bytetrade.io/web3os/installer/pkg/release/app"
+	"bytetrade.io/web3os/installer/pkg/release/manifest"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type Builder struct {
+	olaresRepoRoot  string
+	distPath        string
+	version         string
+	manifestManager *manifest.Manager
+	appManager      *app.Manager
+}
+
+func NewBuilder(olaresRepoRoot, version, cdnURL string, ignoreMissingImages bool) *Builder {
+	distPath := filepath.Join(olaresRepoRoot, ".dist/install-wizard")
+	return &Builder{
+		olaresRepoRoot:  olaresRepoRoot,
+		distPath:        distPath,
+		version:         version,
+		manifestManager: manifest.NewManager(olaresRepoRoot, cdnURL, ignoreMissingImages),
+		appManager:      app.NewManager(olaresRepoRoot, distPath),
+	}
+}
+
+func (b *Builder) Build() (string, error) {
+	// Clean previous build
+	if err := os.RemoveAll(filepath.Join(b.olaresRepoRoot, ".dist")); err != nil {
+		return "", fmt.Errorf("failed to clean previous dist directory: %v", err)
+	}
+
+	// Package apps
+	if err := b.appManager.Package(); err != nil {
+		return "", fmt.Errorf("package apps failed: %v", err)
+	}
+
+	// Build manifest
+	if err := b.manifestManager.Build(); err != nil {
+		return "", fmt.Errorf("manifest build failed: %v", err)
+	}
+
+	// Copy upgrade script, as the current build.sh does
+	if err := util.CopyFile(
+		filepath.Join(b.olaresRepoRoot, "scripts/upgrade.sh"),
+		filepath.Join(b.distPath, "upgrade.sh"),
+	); err != nil {
+		return "", fmt.Errorf("failed to copy upgrade script: %v", err)
+	}
+
+	// archive the install-wizard
+	return b.createFinalPackage()
+
+}
+
+func (b *Builder) createFinalPackage() (string, error) {
+	if err := os.RemoveAll(filepath.Join(b.distPath, "images")); err != nil {
+		return "", err
+	}
+
+	manifestSrc := filepath.Join(b.olaresRepoRoot, ".manifest/installation.manifest")
+	manifestDst := filepath.Join(b.distPath, "installation.manifest")
+	if err := util.MoveFile(manifestSrc, manifestDst); err != nil {
+		return "", err
+	}
+
+	imagesSrc := filepath.Join(b.olaresRepoRoot, ".manifest")
+	imagesDst := filepath.Join(b.distPath, "images")
+	if err := util.MoveDirectory(imagesSrc, imagesDst); err != nil {
+		return "", err
+	}
+
+	versionStr := "v" + b.version
+	files := []string{
+		filepath.Join(b.distPath, "wizard/config/settings/templates/terminus_cr.yaml"),
+		filepath.Join(b.distPath, "install.sh"),
+		filepath.Join(b.distPath, "install.ps1"),
+	}
+
+	for _, file := range files {
+		if err := util.ReplaceInFile(file, "#__VERSION__", b.version); err != nil {
+			return "", err
+		}
+	}
+
+	tarFile := filepath.Join(b.olaresRepoRoot, fmt.Sprintf("install-wizard-%s.tar.gz", versionStr))
+	return tarFile, util.Tar(b.distPath, tarFile, b.distPath)
+}

--- a/pkg/release/manifest/manifest.go
+++ b/pkg/release/manifest/manifest.go
@@ -1,0 +1,427 @@
+package manifest
+
+import (
+	"bufio"
+	"bytetrade.io/web3os/installer/pkg/core/util"
+	"crypto/md5"
+	"fmt"
+	dockerref "github.com/containerd/containerd/reference/docker"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+type Manager struct {
+	olaresRepoRoot      string
+	cdnURL              string
+	ignoreMissingImages bool
+}
+
+func NewManager(olaresRepoRoot, cdnURL string, ignoreMissingImages bool) *Manager {
+	return &Manager{
+		olaresRepoRoot:      olaresRepoRoot,
+		cdnURL:              cdnURL,
+		ignoreMissingImages: ignoreMissingImages,
+	}
+}
+
+func (m *Manager) generateImageManifest() error {
+	manifestDir := filepath.Join(m.olaresRepoRoot, ".manifest")
+	if err := os.RemoveAll(manifestDir); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(manifestDir, 0755); err != nil {
+		return err
+	}
+
+	imageManifest := filepath.Join(manifestDir, "images.mf")
+
+	// Copy default base images
+	if err := util.CopyFile(
+		filepath.Join(m.olaresRepoRoot, "build/manifest/images"),
+		imageManifest,
+	); err != nil {
+		return err
+	}
+
+	if err := util.CopyFile(
+		filepath.Join(m.olaresRepoRoot, "build/manifest/images.node.mf"),
+		filepath.Join(manifestDir, "images.node.mf"),
+	); err != nil {
+		return err
+	}
+
+	// Find images in app modules
+	modules := []string{"frameworks", "libs", "apps", "third-party"}
+	tmpManifest := filepath.Join(manifestDir, "tmp.image.manifest")
+
+	for _, mod := range modules {
+		entries, err := os.ReadDir(filepath.Join(m.olaresRepoRoot, mod))
+		if err != nil {
+			continue
+		}
+
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+
+			chartPath := filepath.Join(m.olaresRepoRoot, mod, entry.Name(), "config")
+			if err := m.findImagesInPath(chartPath, tmpManifest); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Process temporary manifest
+	return m.processTemporaryManifest(tmpManifest, imageManifest)
+}
+
+func (m *Manager) generateDepsManifest() error {
+	depsDir := filepath.Join(m.olaresRepoRoot, ".dependencies")
+	if err := os.RemoveAll(depsDir); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(depsDir, 0755); err != nil {
+		return err
+	}
+
+	// Copy components and pkgs
+	files := []string{"components", "pkgs"}
+	for _, file := range files {
+		if err := util.CopyFile(
+			filepath.Join(m.olaresRepoRoot, "build/manifest", file),
+			filepath.Join(depsDir, file),
+		); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *Manager) Build() error {
+	if err := m.generateImageManifest(); err != nil {
+		return fmt.Errorf("image manifest generation failed: %v", err)
+	}
+
+	if err := m.generateDepsManifest(); err != nil {
+		return fmt.Errorf("deps manifest generation failed: %v", err)
+	}
+
+	// Move dependencies
+	if err := util.MoveDirectory(
+		filepath.Join(m.olaresRepoRoot, ".dependencies"),
+		filepath.Join(m.olaresRepoRoot, ".manifest"),
+	); err != nil {
+		return fmt.Errorf("failed to move dependencies: %v", err)
+	}
+
+	manifestFile := filepath.Join(m.olaresRepoRoot, ".manifest/installation.manifest")
+
+	// Process components and pkgs
+	deps := []string{"components", "pkgs"}
+	for _, dep := range deps {
+		if err := m.processDependencies(dep, manifestFile); err != nil {
+			return err
+		}
+	}
+
+	return m.processImages(manifestFile)
+}
+
+func (m *Manager) downloadChecksum(name string) (string, error) {
+	resp, err := http.Get(fmt.Sprintf("%s/%s.checksum.txt", m.cdnURL, name))
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	// as for now
+	// the response status code of fetching a missing checksum
+	// is 403 rather than 404
+	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusForbidden {
+			return "", nil
+		}
+		return "", fmt.Errorf("failed to download checksum, status code: %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read http body for checksum: %v", err)
+	}
+
+	return strings.Fields(string(body))[0], nil
+}
+
+func (m *Manager) processDependencies(depType, manifestFile string) error {
+	file, err := os.Open(filepath.Join(m.olaresRepoRoot, ".manifest", depType))
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	manifestOut, err := os.OpenFile(manifestFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer manifestOut.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+
+		fields := strings.Split(line, ",")
+		if len(fields) < 5 {
+			return fmt.Errorf("invalid format: %s", line)
+		}
+
+		filename := fields[0]
+		path := fields[1]
+		name := fmt.Sprintf("%x", md5.Sum([]byte(filename)))
+
+		urlAMD64 := name
+		urlARM64 := "arm64/" + name
+
+		fmt.Printf("downloading md5 checksum for dependency %s, object: %s\n", filename, name)
+
+		checksumAMD64, err := m.downloadChecksum(urlAMD64)
+		if err != nil {
+			return err
+		}
+
+		checksumARM64, err := m.downloadChecksum(urlARM64)
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprintf(manifestOut, "%s,%s,%s,%s,%s,%s,%s,%s\n",
+			filename, path, depType, urlAMD64, checksumAMD64, urlARM64, checksumARM64, fields[4])
+	}
+
+	return scanner.Err()
+}
+
+func (m *Manager) processImages(manifestFile string) error {
+	path := "images"
+	manifestOut, err := os.OpenFile(manifestFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer manifestOut.Close()
+
+	imagesList, err := os.Open(filepath.Join(m.olaresRepoRoot, ".manifest/images.mf"))
+	if err != nil {
+		return err
+	}
+	defer imagesList.Close()
+
+	scanner := bufio.NewScanner(imagesList)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+
+		// Generate MD5 hash of the image name
+		name := fmt.Sprintf("%x", md5.Sum([]byte(line)))
+
+		// Define URLs for both architectures
+		urlAMD64 := name + ".tar.gz"
+		urlARM64 := "arm64/" + name + ".tar.gz"
+
+		fmt.Printf("downloading checksum for image %s, object: %s\n", line, urlAMD64)
+
+		checksumAMD64, err := m.downloadChecksum(name)
+		if err != nil {
+			return fmt.Errorf("failed to download AMD64 checksum for %s: %v", line, err)
+		}
+		if checksumAMD64 == "" {
+			if m.ignoreMissingImages {
+				fmt.Printf("skipping image %s due to missing checksum\n", line)
+				continue
+			}
+			return fmt.Errorf("got empty checksum for image %s", line)
+		}
+
+		checksumARM64, err := m.downloadChecksum("arm64/" + name)
+		if err != nil {
+			return fmt.Errorf("failed to download ARM64 checksum for %s: %v", line, err)
+		}
+
+		// Write to manifest file
+		_, err = fmt.Fprintf(manifestOut, "%s.tar.gz,%s,%s,%s,%s,%s,%s,%s\n",
+			name, path, "images.mf", urlAMD64, checksumAMD64, urlARM64, checksumARM64, line)
+		if err != nil {
+			return fmt.Errorf("failed to write to manifest file: %v", err)
+		}
+	}
+
+	return scanner.Err()
+}
+
+func (m *Manager) findImagesInPath(path string, tmpManifest string) error {
+	// Open temporary manifest file for appending
+	tmpFile, err := os.OpenFile(tmpManifest, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer tmpFile.Close()
+
+	// Walk through all yaml files in the path
+	err = filepath.Walk(path, func(filePath string, info os.FileInfo, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				relPath, _ := filepath.Rel(m.olaresRepoRoot, filePath)
+				fmt.Printf("skipping non existing path: %s\n", relPath)
+				return nil
+			}
+			return err
+		}
+
+		// Only process yaml files
+		if !info.IsDir() && (strings.HasSuffix(filePath, ".yaml") || strings.HasSuffix(filePath, ".yml")) {
+			targetFile, err := os.Open(filePath)
+			if err != nil {
+				return err
+			}
+			defer targetFile.Close()
+
+			relPath, _ := filepath.Rel(m.olaresRepoRoot, filePath)
+			scanner := bufio.NewScanner(targetFile)
+			for scanner.Scan() {
+				line := scanner.Text()
+				if !strings.HasPrefix(strings.TrimSpace(line), "image:") {
+					continue
+				}
+				image := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), "image:"))
+				image = strings.Trim(image, "'")
+				image = strings.Trim(image, "\"")
+
+				// probably some other config yaml
+				// instead of a container spec
+				if image == "" {
+					fmt.Printf("skipping empty image key in file: %s, line: %s\n", relPath, line)
+					continue
+				}
+
+				image, err = m.patchImage(image)
+				if err != nil {
+					return fmt.Errorf("failed to patch image %s: %v", image, err)
+				}
+
+				if _, err := dockerref.ParseDockerRef(image); err != nil {
+					fmt.Printf("skipping invalid image key: %s in file: %s, line: %s\n", image, relPath, line)
+					continue
+				}
+
+				// Skip specific images
+				if strings.Contains(image, "nitro") || strings.Contains(image, "orion") {
+					fmt.Printf("skipping image %s in file: %s, line: %s\n", image, relPath, line)
+					continue
+				}
+
+				fmt.Printf("found image %s in file %s\n", image, relPath)
+				// Write image to temporary manifest
+				if _, err := fmt.Fprintln(tmpFile, image); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	})
+
+	return err
+}
+
+func (m *Manager) processTemporaryManifest(tmpManifest, imageManifest string) error {
+	// Read temporary manifest
+	tmpContent, err := os.ReadFile(tmpManifest)
+	if err != nil {
+		return err
+	}
+
+	// Create a map to store unique images
+	uniqueImages := make(map[string]struct{})
+
+	// remove this logic for now
+	// to maintain a same order as the one
+	// built from shell script
+	// Add existing images from image manifest
+	//existingContent, err := os.ReadFile(imageManifest)
+	//if err != nil {
+	//	return err
+	//}
+	//for _, line := range strings.Split(string(existingContent), "\n") {
+	//	if line = strings.TrimSpace(line); line != "" {
+	//		uniqueImages[line] = struct{}{}
+	//	}
+	//}
+
+	// Add new images from temporary manifest
+	for _, line := range strings.Split(string(tmpContent), "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			uniqueImages[line] = struct{}{}
+		}
+	}
+
+	// Write unique images back to image manifest
+	manifestFile, err := os.OpenFile(imageManifest, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
+	if err != nil {
+		return err
+	}
+	defer manifestFile.Close()
+
+	// Convert map to sorted slice for consistent output
+	var images []string
+	for image := range uniqueImages {
+		images = append(images, image)
+	}
+	sort.Strings(images)
+
+	// Write sorted images to manifest
+	for _, image := range images {
+		if _, err := fmt.Fprintln(manifestFile, image); err != nil {
+			return err
+		}
+	}
+
+	// Clean up temporary manifest
+	return os.Remove(tmpManifest)
+}
+
+// Helper function to patch extracted image name
+// before validating it
+// for now just backup-server is patched
+func (m *Manager) patchImage(image string) (string, error) {
+	backupServerImageVersionTpl := "{{ $backupVersion }}"
+	if !strings.Contains(image, backupServerImageVersionTpl) {
+		return image, nil
+	}
+	backupConfigPath := filepath.Join(m.olaresRepoRoot, "frameworks/backup-server/config/cluster/deploy/backup_server.yaml")
+	content, err := os.ReadFile(backupConfigPath)
+	if err != nil {
+		return "", err
+	}
+
+	// Extract backup version using regex
+	re := regexp.MustCompile(`{{ \$backupVersion := "(.*)" }}`)
+	matches := re.FindStringSubmatch(string(content))
+	if len(matches) != 2 {
+		return "", fmt.Errorf("backup version not found in config")
+	}
+	backupVersion := matches[1]
+
+	// Replace version
+	fmt.Printf("patching backup server version to %s\n", backupVersion)
+	image = strings.ReplaceAll(image, backupServerImageVersionTpl, backupVersion)
+	return image, nil
+}

--- a/pkg/terminus/tasks.go
+++ b/pkg/terminus/tasks.go
@@ -355,7 +355,7 @@ func (a *PrepareFilesForETCDIPChange) Execute(runtime connector.Runtime) error {
 			return nil
 		}
 		if strings.HasPrefix(filepath.Base(path), "ca") {
-			if err := util.CopyFile(path, dstCertsDir); err != nil {
+			if err := util.CopyFileToDir(path, dstCertsDir); err != nil {
 				return err
 			}
 		}

--- a/pkg/utils/file.go
+++ b/pkg/utils/file.go
@@ -17,19 +17,14 @@
 package utils
 
 import (
-	"archive/tar"
-	"compress/gzip"
+	"bytetrade.io/web3os/installer/pkg/core/logger"
 	"crypto/md5"
 	"fmt"
 	"io"
-	"io/fs"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
-	"strings"
-
-	"bytetrade.io/web3os/installer/pkg/core/logger"
 
 	"github.com/pkg/errors"
 	"github.com/shurcooL/httpfs/vfsutil"
@@ -59,39 +54,12 @@ func CreateDir(path string) error {
 	return nil
 }
 
-func IsDir(path string) bool {
-	fi, err := os.Stat(path)
-	if err != nil {
-		return false
-	}
-	return fi.IsDir()
-}
-
 func IsSymLink(path string) (bool, error) {
 	fileInfo, err := os.Lstat(path)
 	if err != nil {
 		return false, err
 	}
 	return fileInfo.Mode()&os.ModeSymlink != 0, nil
-}
-
-func CountDirFiles(dirName string) int {
-	if !IsDir(dirName) {
-		return 0
-	}
-	var count int
-	err := filepath.Walk(dirName, func(path string, info os.FileInfo, err error) error {
-		if info.IsDir() {
-			return nil
-		}
-		count++
-		return nil
-	})
-	if err != nil {
-		logger.Fatalf("count dir files failed %v", err)
-		return 0
-	}
-	return count
 }
 
 func FileMD5(path string) (string, error) {
@@ -123,155 +91,8 @@ func LocalMd5Sum(src string) string {
 	return md5Str
 }
 
-func MkFileFullPathDir(fileName string) error {
-	localDir := filepath.Dir(fileName)
-	err := Mkdir(localDir)
-	if err != nil {
-		return fmt.Errorf("create local dir %s failed: %v", localDir, err)
-	}
-	return nil
-}
-
 func Mkdir(dirName string) error {
 	return os.MkdirAll(dirName, os.ModePerm)
-}
-
-func WriteFile(fileName string, content []byte) error {
-	dir := filepath.Dir(fileName)
-	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		if err = os.MkdirAll(dir, 0755); err != nil {
-			return err
-		}
-	}
-
-	if err := ioutil.WriteFile(fileName, content, 0644); err != nil {
-		return err
-	}
-	return nil
-}
-
-func AppendFile(fileName string, content string) error {
-	if !IsExist(fileName) {
-		return errors.Errorf("file %s not exist", fileName)
-	}
-
-	file, err := os.OpenFile(fileName, os.O_APPEND|os.O_WRONLY, 0644)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
-	if _, err = file.WriteString(content); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func Tar(src, dst, trimPrefix string) error {
-	fw, err := os.Create(dst)
-	if err != nil {
-		return err
-	}
-	defer fw.Close()
-
-	gw := gzip.NewWriter(fw)
-	defer gw.Close()
-
-	tw := tar.NewWriter(gw)
-	defer tw.Close()
-
-	return filepath.Walk(src, func(path string, info fs.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-
-		hdr, err := tar.FileInfoHeader(info, "")
-		if err != nil {
-			return err
-		}
-
-		if !info.Mode().IsRegular() {
-			return nil
-		}
-
-		fr, err := os.Open(path)
-		defer fr.Close()
-		if err != nil {
-			return err
-		}
-
-		path = strings.TrimPrefix(path, trimPrefix)
-		fmt.Println(strings.TrimPrefix(path, string(filepath.Separator)))
-
-		hdr.Name = strings.TrimPrefix(path, string(filepath.Separator))
-		if err := tw.WriteHeader(hdr); err != nil {
-			return err
-		}
-
-		if _, err := io.Copy(tw, fr); err != nil {
-			return err
-		}
-
-		return nil
-	})
-}
-
-func Untar(src, dst string) error {
-	fr, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer fr.Close()
-
-	gr, err := gzip.NewReader(fr)
-	if err != nil {
-		return err
-	}
-	defer gr.Close()
-
-	tr := tar.NewReader(gr)
-	for {
-		hdr, err := tr.Next()
-
-		switch {
-		case err == io.EOF:
-			return nil
-		case err != nil:
-			return err
-		case hdr == nil:
-			continue
-		}
-
-		dstPath := filepath.Join(dst, hdr.Name)
-
-		switch hdr.Typeflag {
-		case tar.TypeDir:
-			if !IsExist(dstPath) && IsDir(dstPath) {
-				if err := CreateDir(dstPath); err != nil {
-					return err
-				}
-			}
-		case tar.TypeReg:
-			if dir := filepath.Dir(dstPath); !IsExist(dir) {
-				if err := CreateDir(dir); err != nil {
-					return err
-				}
-			}
-
-			file, err := os.OpenFile(dstPath, os.O_CREATE|os.O_RDWR, os.FileMode(hdr.Mode))
-			if err != nil {
-				return err
-			}
-
-			if _, err = io.Copy(file, tr); err != nil {
-				return err
-			}
-
-			fmt.Println(dstPath)
-			file.Close()
-		}
-	}
 }
 
 func CopyEmbed(assets http.FileSystem, embeddedDir, dst string) error {
@@ -296,20 +117,4 @@ func CopyEmbed(assets http.FileSystem, embeddedDir, dst string) error {
 
 		return ioutil.WriteFile(targetPath, data, os.ModePerm)
 	})
-}
-
-func GetRealPath(p string) (string, error) {
-	ok, err := IsSymLink(p)
-	if err != nil {
-		return p, err
-	}
-	if !ok {
-		return p, nil
-	}
-
-	target, err := os.Readlink(p)
-	if err != nil {
-		return p, err
-	}
-	return target, nil
 }


### PR DESCRIPTION
add command `olares-cli olares release` to build a local release based on a local `Olares` repo.

basically, it's a port of [build.sh](https://github.com/beclab/Olares/blob/main/scripts/build.sh) and other relevant scripts in golang, only without the upload functions.