### PR TITLE
feat: make juiceFS an option in prepare phase

### DIFF
--- a/cmd/ctl/options/cli_options.go
+++ b/cmd/ctl/options/cli_options.go
@@ -21,7 +21,7 @@ func NewCliTerminusUninstallOptions() *CliTerminusUninstallOptions {
 
 func (o *CliTerminusUninstallOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&o.Version, "version", "v", "", "Set Olares version, e.g., 1.10.0, 1.10.0-20241109")
-	cmd.Flags().StringVar(&o.BaseDir, "base-dir", "", "Set Olares package base dir, defaults to $HOME/"+cc.DefaultBaseDir)
+	cmd.Flags().StringVarP(&o.BaseDir, "base-dir", "b", "", "Set Olares package base dir, defaults to $HOME/"+cc.DefaultBaseDir)
 	cmd.Flags().BoolVar(&o.All, "all", false, "Uninstall Olares completely, including prepared dependencies")
 	cmd.Flags().StringVar(&o.Phase, "phase", cluster.PhaseInstall.String(), "Uninstall from a specified phase and revert to the previous one. For example, using --phase install will remove the tasks performed in the 'install' phase, effectively returning the system to the 'prepare' state.")
 	cmd.Flags().BoolVar(&o.Quiet, "quiet", false, "Quiet mode, default: false")
@@ -32,7 +32,6 @@ type CliTerminusInstallOptions struct {
 	KubeType        string
 	MiniKubeProfile string
 	BaseDir         string
-	Manifest        string
 }
 
 func NewCliTerminusInstallOptions() *CliTerminusInstallOptions {
@@ -44,7 +43,6 @@ func (o *CliTerminusInstallOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.KubeType, "kube", "k3s", "Set kube type, e.g., k3s or k8s")
 	cmd.Flags().StringVarP(&o.MiniKubeProfile, "profile", "p", "", "Set Minikube profile name, only in MacOS platform, defaults to "+common.MinikubeDefaultProfile)
 	cmd.Flags().StringVarP(&o.BaseDir, "base-dir", "b", "", "Set Olares package base dir, defaults to $HOME/"+cc.DefaultBaseDir)
-	cmd.Flags().StringVar(&o.Manifest, "manifest", "", "Set package manifest file , defaults to {base-dir}/versions/v{version}installation.manifest")
 }
 
 type CliPrepareSystemOptions struct {
@@ -52,8 +50,8 @@ type CliPrepareSystemOptions struct {
 	KubeType        string
 	RegistryMirrors string
 	BaseDir         string
-	Manifest        string
 	MinikubeProfile string
+	WithJuiceFS     bool
 }
 
 func NewCliPrepareSystemOptions() *CliPrepareSystemOptions {
@@ -65,8 +63,8 @@ func (o *CliPrepareSystemOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.KubeType, "kube", "k3s", "Set kube type, e.g., k3s or k8s")
 	cmd.Flags().StringVarP(&o.RegistryMirrors, "registry-mirrors", "r", "", "Docker Container registry mirrors, multiple mirrors are separated by commas")
 	cmd.Flags().StringVarP(&o.BaseDir, "base-dir", "b", "", "Set Olares package base dir, defaults to $HOME/"+cc.DefaultBaseDir)
-	cmd.Flags().StringVar(&o.Manifest, "manifest", "", "Set package manifest file , defaults to {base-dir}/versions/v{version}installation.manifest")
 	cmd.Flags().StringVarP(&o.MinikubeProfile, "profile", "p", "", "Set Minikube profile name, only in MacOS platform, defaults to "+common.MinikubeDefaultProfile)
+	cmd.Flags().BoolVar(&o.WithJuiceFS, "with-juicefs", true, "Use JuiceFS as the base storage for Olares workloads, rather than the local disk.")
 }
 
 type ChangeIPOptions struct {
@@ -82,7 +80,7 @@ func NewChangeIPOptions() *ChangeIPOptions {
 
 func (o *ChangeIPOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&o.Version, "version", "v", "", "Set Olares version, e.g., 1.10.0, 1.10.0-20241109")
-	cmd.Flags().StringVar(&o.BaseDir, "base-dir", "", "Set Olares package base dir, defaults to $HOME/"+cc.DefaultBaseDir)
+	cmd.Flags().StringVarP(&o.BaseDir, "base-dir", "b", "", "Set Olares package base dir, defaults to $HOME/"+cc.DefaultBaseDir)
 	cmd.Flags().StringVarP(&o.WSLDistribution, "distribution", "d", "", "Set WSL distribution name, only in Windows platform, defaults to "+common.WSLDefaultDistribution)
 	cmd.Flags().StringVarP(&o.MinikubeProfile, "profile", "p", "", "Set Minikube profile name, only in MacOS platform, defaults to "+common.MinikubeDefaultProfile)
 }

--- a/cmd/ctl/os/install.go
+++ b/cmd/ctl/os/install.go
@@ -21,7 +21,7 @@ func NewCmdInstallOs() *cobra.Command {
 	o := NewInstallOsOptions()
 	cmd := &cobra.Command{
 		Use:   "install",
-		Short: "Install Terminus",
+		Short: "Install Olares",
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := pipelines.CliInstallTerminusPipeline(o.InstallOptions); err != nil {
 				logger.Fatalf("install Olares error: %v", err)

--- a/cmd/ctl/root.go
+++ b/cmd/ctl/root.go
@@ -9,7 +9,7 @@ import (
 
 func NewDefaultCommand() *cobra.Command {
 	cmds := &cobra.Command{
-		Use:               "Olares Cli",
+		Use:               "olares-cli",
 		Short:             "Olares Installer",
 		CompletionOptions: cobra.CompletionOptions{DisableDefaultCmd: true},
 		Version:           version.VERSION,

--- a/pkg/common/kube_runtime.go
+++ b/pkg/common/kube_runtime.go
@@ -92,7 +92,12 @@ type Argument struct {
 	Provider storage.Provider `json:"-"`
 	// User
 	User *User `json:"user"`
-	// storage
+	// if juicefs is opted off, the local storage is used directly
+	// only used in prepare phase
+	// the existence of juicefs should be checked in other phases
+	// to avoid wrong information given by user
+	WithJuiceFS bool `json:"with_juicefs"`
+	// the object storage service used as backend for JuiceFS
 	Storage                *Storage           `json:"storage"`
 	PublicNetworkInfo      *PublicNetworkInfo `json:"public_network_info"`
 	GPU                    *GPU               `json:"gpu"`

--- a/pkg/k3s/tasks.go
+++ b/pkg/k3s/tasks.go
@@ -231,7 +231,7 @@ func (g *GenerateK3sService) Execute(runtime connector.Runtime) error {
 		"SchedulerArgs":          kubeSchedulerArgs,
 		"KubeletArgs":            kubeletArgs,
 		"KubeProxyArgs":          kubeProxyArgs,
-		"JuiceFSPreCheckEnabled": !runtime.GetSystemInfo().IsWsl(),
+		"JuiceFSPreCheckEnabled": util.IsExist(storage.JuiceFsServiceFile),
 		"JuiceFSServiceUnit":     storagetpl.JuicefsService.Name(),
 		"JuiceFSBinPath":         storage.JuiceFsFile,
 		"JuiceFSMountPoint":      storage.OlaresJuiceFSRootDir,

--- a/pkg/kubernetes/tasks.go
+++ b/pkg/kubernetes/tasks.go
@@ -230,7 +230,7 @@ func (t *GenerateKubeletService) Execute(runtime connector.Runtime) error {
 		Template: templates.KubeletService,
 		Dst:      filepath.Join("/etc/systemd/system/", templates.KubeletService.Name()),
 		Data: util.Data{
-			"JuiceFSPreCheckEnabled": !runtime.GetSystemInfo().IsWsl(),
+			"JuiceFSPreCheckEnabled": util.IsExist(storage.JuiceFsServiceFile),
 			"JuiceFSServiceUnit":     storagetpl.JuicefsService.Name(),
 			"JuiceFSBinPath":         storage.JuiceFsFile,
 			"JuiceFSMountPoint":      storage.OlaresJuiceFSRootDir,

--- a/pkg/phase/system/linux.go
+++ b/pkg/phase/system/linux.go
@@ -100,7 +100,10 @@ func (l *linuxPhaseBuilder) build() []module.Module {
 				&storage.InitStorageModule{Skip: !l.runtime.Arg.IsCloudInstance},
 			}
 		}).withCloud(l.runtime)...).
-		addModule(l.storage()...).
+		addModule(storageModuleBuilder(func() []module.Module {
+			return l.storage()
+
+		}).withJuiceFS(l.runtime)...).
 		addModule(cloudModuleBuilder(l.installContainerModule).withoutCloud(l.runtime)...).
 		addModule(cloudModuleBuilder(func() []module.Module {
 			// unitl now, system ready

--- a/pkg/phase/system/utils.go
+++ b/pkg/phase/system/utils.go
@@ -39,6 +39,19 @@ func (m cloudModuleBuilder) withoutCloud(runtime *common.KubeRuntime) []module.M
 	return nil
 }
 
+type storageModuleBuilder func() []module.Module
+
+func (m storageModuleBuilder) withJuiceFS(runtime *common.KubeRuntime) []module.Module {
+	// if juicefs is enabled
+	// install redis/minio/juicefs
+	if runtime.Arg.WithJuiceFS {
+		return m()
+	}
+	// use local disk storage
+	// so nothing need to be done
+	return nil
+}
+
 type gpuModuleBuilder func() []module.Module
 
 func (m gpuModuleBuilder) withGPU(runtime *common.KubeRuntime) []module.Module {

--- a/pkg/pipelines/install_terminus.go
+++ b/pkg/pipelines/install_terminus.go
@@ -37,10 +37,7 @@ func CliInstallTerminusPipeline(opts *options.CliTerminusInstallOptions) error {
 		return nil
 	}
 
-	manifest := opts.Manifest
-	if manifest == "" {
-		manifest = path.Join(runtime.GetInstallerDir(), "installation.manifest")
-	}
+	manifest := path.Join(runtime.GetInstallerDir(), "installation.manifest")
 
 	runtime.Arg.SetManifest(manifest)
 

--- a/pkg/pipelines/prepare_system.go
+++ b/pkg/pipelines/prepare_system.go
@@ -28,16 +28,16 @@ func PrepareSystemPipeline(opts *options.CliPrepareSystemOptions) error {
 	arg.SetStorage(getStorageValueFromEnv())
 	arg.SetTokenMaxAge()
 	arg.SetReverseProxy()
+	if opts.WithJuiceFS {
+		arg.WithJuiceFS = true
+	}
 
 	runtime, err := common.NewKubeRuntime(common.AllInOne, *arg)
 	if err != nil {
 		return err
 	}
 
-	manifest := opts.Manifest
-	if manifest == "" {
-		manifest = path.Join(runtime.GetInstallerDir(), "installation.manifest")
-	}
+	manifest := path.Join(runtime.GetInstallerDir(), "installation.manifest")
 
 	runtime.Arg.SetManifest(manifest)
 


### PR DESCRIPTION
a new option `--with-juicefs` is added to the `prepare` command, which has a default value of true, and if set to false, JuiceFS (along with its dependencies Redis and MinIO) is not installed, and the local filesystem will be accessed by the Olares workloads directly.