### PR TITLE
perf: when changing ip, only restart pods using host ip if juicefs disabled

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,8 +22,8 @@ builds:
       - goos: windows
         goarch: arm
     ldflags:
-      - -s
-      - -w
+      - s
+      - w
       - -X bytetrade.io/web3os/installer/version.VERSION={{ .Version }}
 dist: ./output
 archives:

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -240,6 +240,8 @@ const (
 
 	CacheAppServicePod = "app_service_pod_name"
 	CacheAppValues     = "app_built_in_values"
+
+	CacheCountPodsUsingHostIP = "count_pods_using_host_ip"
 )
 
 const (


### PR DESCRIPTION
note that the `Status` column in the output of `kubectl get pod` is a calculated value and does not equal to the `.status.phase` field of a pod object, which is almost always `Running`, so we shouldn't use this field to determine if a pod is normally running or not.

also, `kubectl delete pod` waits for a pod to be actually gone while the `Delete()` method of Kubernetes clientset does not, so we have to wait for it ourselves when using Kubernetes clientset to delete pods.