### PR TITLE
fix: use the logger from std lib at cmd entry

### DIFF
--- a/cmd/ctl/os/download.go
+++ b/cmd/ctl/os/download.go
@@ -2,9 +2,9 @@ package os
 
 import (
 	"bytetrade.io/web3os/installer/cmd/ctl/options"
-	"bytetrade.io/web3os/installer/pkg/core/logger"
 	"bytetrade.io/web3os/installer/pkg/pipelines"
 	"github.com/spf13/cobra"
+	"log"
 )
 
 func NewCmdRootDownload() *cobra.Command {
@@ -28,7 +28,7 @@ func NewCmdDownload() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 
 			if err := pipelines.DownloadInstallationPackage(o); err != nil {
-				logger.Fatalf("download installation package error: %v", err)
+				log.Fatalf("error: %v", err)
 			}
 		},
 	}
@@ -45,7 +45,7 @@ func NewCmdDownloadWizard() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 
 			if err := pipelines.DownloadInstallationWizard(o); err != nil {
-				logger.Fatalf("download installation wizard error: %v", err)
+				log.Fatalf("error: %v", err)
 			}
 		},
 	}
@@ -62,7 +62,7 @@ func NewCmdCheckDownload() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 
 			if err := pipelines.CheckDownloadInstallationPackage(o); err != nil {
-				logger.Errorf("check download error: %v", err)
+				log.Fatalf("error: %v", err)
 			}
 		},
 	}

--- a/cmd/ctl/os/install.go
+++ b/cmd/ctl/os/install.go
@@ -2,9 +2,9 @@ package os
 
 import (
 	"bytetrade.io/web3os/installer/cmd/ctl/options"
-	"bytetrade.io/web3os/installer/pkg/core/logger"
 	"bytetrade.io/web3os/installer/pkg/pipelines"
 	"github.com/spf13/cobra"
+	"log"
 )
 
 type InstallOsOptions struct {
@@ -24,7 +24,7 @@ func NewCmdInstallOs() *cobra.Command {
 		Short: "Install Olares",
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := pipelines.CliInstallTerminusPipeline(o.InstallOptions); err != nil {
-				logger.Fatalf("install Olares error: %v", err)
+				log.Fatalf("error: %v", err)
 			}
 		},
 	}

--- a/cmd/ctl/os/prepare.go
+++ b/cmd/ctl/os/prepare.go
@@ -2,9 +2,9 @@ package os
 
 import (
 	"bytetrade.io/web3os/installer/cmd/ctl/options"
-	"bytetrade.io/web3os/installer/pkg/core/logger"
 	"bytetrade.io/web3os/installer/pkg/pipelines"
 	"github.com/spf13/cobra"
+	"log"
 )
 
 type PrepareSystemOptions struct {
@@ -25,7 +25,7 @@ func NewCmdPrepare() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 
 			if err := pipelines.PrepareSystemPipeline(o.PrepareOptions); err != nil {
-				logger.Fatalf("prepare system error: %v", err)
+				log.Fatalf("error: %v", err)
 			}
 		},
 	}

--- a/cmd/ctl/os/uninstall.go
+++ b/cmd/ctl/os/uninstall.go
@@ -4,6 +4,7 @@ import (
 	"bytetrade.io/web3os/installer/cmd/ctl/options"
 	"bytetrade.io/web3os/installer/pkg/pipelines"
 	"github.com/spf13/cobra"
+	"log"
 )
 
 type UninstallOsOptions struct {
@@ -22,7 +23,10 @@ func NewCmdUninstallOs() *cobra.Command {
 		Use:   "uninstall",
 		Short: "Uninstall Olares",
 		Run: func(cmd *cobra.Command, args []string) {
-			pipelines.UninstallTerminusPipeline(o.UninstallOptions)
+			err := pipelines.UninstallTerminusPipeline(o.UninstallOptions)
+			if err != nil {
+				log.Fatalf("error: %v", err)
+			}
 		},
 	}
 	o.UninstallOptions.AddFlags(cmd)

--- a/pkg/pipelines/install_terminus.go
+++ b/pkg/pipelines/install_terminus.go
@@ -3,6 +3,7 @@ package pipelines
 import (
 	"encoding/base64"
 	"fmt"
+	"github.com/pkg/errors"
 	"io/ioutil"
 	"path"
 	"path/filepath"
@@ -18,8 +19,7 @@ import (
 func CliInstallTerminusPipeline(opts *options.CliTerminusInstallOptions) error {
 	var terminusVersion, _ = phase.GetTerminusVersion()
 	if terminusVersion != "" {
-		fmt.Printf("Olares is already installed, please uninstall it first.")
-		return nil
+		return errors.New("Olares is already installed, please uninstall it first.")
 	}
 
 	arg := common.NewArgument()
@@ -33,8 +33,7 @@ func CliInstallTerminusPipeline(opts *options.CliTerminusInstallOptions) error {
 
 	runtime, err := common.NewKubeRuntime(common.AllInOne, *arg)
 	if err != nil {
-		fmt.Printf("Error creating installation runtime: %v\n", err)
-		return nil
+		return fmt.Errorf("error creating runtime: %v", err)
 	}
 
 	manifest := path.Join(runtime.GetInstallerDir(), "installation.manifest")

--- a/pkg/pipelines/prepare_system.go
+++ b/pkg/pipelines/prepare_system.go
@@ -1,6 +1,7 @@
 package pipelines
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -15,8 +16,7 @@ func PrepareSystemPipeline(opts *options.CliPrepareSystemOptions) error {
 
 	var terminusVersion, _ = phase.GetTerminusVersion()
 	if terminusVersion != "" {
-		fmt.Printf("Olares is already installed, please uninstall it first.")
-		return nil
+		return errors.New("Olares is already installed, please uninstall it first.")
 	}
 
 	var arg = common.NewArgument()
@@ -34,7 +34,7 @@ func PrepareSystemPipeline(opts *options.CliPrepareSystemOptions) error {
 
 	runtime, err := common.NewKubeRuntime(common.AllInOne, *arg)
 	if err != nil {
-		return err
+		return fmt.Errorf("error creating runtime: %w", err)
 	}
 
 	manifest := path.Join(runtime.GetInstallerDir(), "installation.manifest")


### PR DESCRIPTION
the  logger in the `"bytetrade.io/web3os/installer/pkg/core/logger"` package, used across this project, is initialized in:
https://github.com/beclab/Installer/blob/f801ceeb8ac7eae21cdd0744e1b6eb34e658028a/pkg/core/connector/runtime.go#L81
which is typically called in the `Run` method of a command like this:
https://github.com/beclab/Installer/blob/f801ceeb8ac7eae21cdd0744e1b6eb34e658028a/cmd/ctl/os/install.go#L26-L28
but other errors might also be returned *before* the logger is actually initialized, resulting in a nil pointer panic.
we should just simply use the logger from the standard library in this case, because:
- if the command errors out before the logger is initialized, it means no task has been executed, thus a simple console log is enough.
- if the command errors out after the logger is initialized, the actual log is already handled by the logger and it's also ok to use the standard log lib to print the error message at the end and exit.