### PR TITLE
feat: detect public ip and adjust the setting of "selfhosted"

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,8 +22,8 @@ builds:
       - goos: windows
         goarch: arm
     ldflags:
-      - s
-      - w
+      - -s
+      - -w
       - -X bytetrade.io/web3os/installer/version.VERSION={{ .Version }}
 dist: ./output
 archives:

--- a/pkg/common/kube_runtime.go
+++ b/pkg/common/kube_runtime.go
@@ -19,6 +19,7 @@ package common
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -122,8 +123,14 @@ type Argument struct {
 }
 
 type PublicNetworkInfo struct {
-	PublicIp string `json:"aws_public_ip"`
-	Hostname string `json:"aws_hostname"`
+	// OSPublicIPs contains a list of public ip(s)
+	// by looking at local network interfaces
+	// if any
+	OSPublicIPs []net.IP `json:"os_public_ips"`
+
+	// AWS contains the info retrieved from the AWS instance metadata service
+	// if any
+	AWSPublicIP net.IP `json:"aws"`
 }
 
 type User struct {
@@ -332,7 +339,7 @@ func (a *Argument) SetKubernetesVersion(kubeType string, kubeVersion string) {
 
 func (a *Argument) SetBaseDir(dir string) {
 	a.BaseDir = dir
-	if !filepath.IsAbs(dir) {
+	if dir != "" && !filepath.IsAbs(dir) {
 		dir, _ = filepath.Abs(dir)
 		if dir != "" {
 			a.BaseDir = dir

--- a/pkg/phase/cluster/changeip.go
+++ b/pkg/phase/cluster/changeip.go
@@ -23,7 +23,7 @@ func ChangeIP(runtime *common.KubeRuntime) *pipeline.Pipeline {
 	}
 
 	return &pipeline.Pipeline{
-		Name:    "Change the local IP address of Olares OS components",
+		Name:    "Change the IP address of Olares OS components",
 		Modules: modules,
 		Runtime: runtime,
 	}

--- a/pkg/terminus/prepares.go
+++ b/pkg/terminus/prepares.go
@@ -3,35 +3,7 @@ package terminus
 import (
 	"bytetrade.io/web3os/installer/pkg/common"
 	"bytetrade.io/web3os/installer/pkg/core/connector"
-	"net"
 )
-
-type CheckPublicNetworkInfo struct {
-	common.KubePrepare
-}
-
-func (p *CheckPublicNetworkInfo) PreCheck(runtime connector.Runtime) (bool, error) {
-	if runtime.GetSystemInfo().IsDarwin() {
-		return true, nil
-	}
-	var cmd = "curl --connect-timeout 5 -sL http://169.254.169.254/latest/meta-data/public-ipv4"
-	var publicIp, _ = runtime.GetRunner().Host.SudoCmd(cmd, false, false)
-	if publicIp == "" || net.ParseIP(publicIp) == nil {
-		cmd = "curl -s --retry 5 --retry-delay 1 --retry-max-time 10 http://ifconfig.me"
-		publicIp, _ = runtime.GetRunner().Host.SudoCmd(cmd, false, false)
-	}
-	if net.ParseIP(publicIp) != nil {
-		p.KubeConf.Arg.PublicNetworkInfo.PublicIp = publicIp
-	}
-
-	cmd = "curl --connect-timeout 5 -sL http://169.254.169.254/latest/meta-data/public-hostname"
-	var hostname, err = runtime.GetRunner().Host.SudoCmd(cmd, false, false)
-	if err == nil {
-		p.KubeConf.Arg.PublicNetworkInfo.Hostname = hostname
-	}
-
-	return true, nil
-}
 
 type NotEqualDesiredVersion struct {
 	common.KubePrepare


### PR DESCRIPTION
detect public IP when installing Olares by:
1. check whether the machine has a local network interface to which a public IP is bound
2. if the machine is an AWS EC2 instance, check whether it has an associated public IP address by contacting the IMDS service

if a public IP is detected, the `selfhosted` setting is turned off when installing related components.