### PR TITLE
fix: ignore the value of Windows gpu env vars during wsl installation

### DIFF
--- a/pkg/phase/cluster/linux.go
+++ b/pkg/phase/cluster/linux.go
@@ -34,9 +34,13 @@ func (l *linuxInstallPhaseBuilder) installCluster() phase {
 }
 
 func (l *linuxInstallPhaseBuilder) installGpuPlugin() phase {
+	var skipGpuPlugin = !l.runtime.Arg.GPU.Enable
+	if l.runtime.GetSystemInfo().IsWsl() {
+		skipGpuPlugin = false
+	}
 	return []module.Module{
 		&gpu.RestartK3sServiceModule{Skip: !(l.runtime.Arg.Kubetype == common.K3s)},
-		&gpu.InstallPluginModule{Skip: !l.runtime.Arg.GPU.Enable},
+		&gpu.InstallPluginModule{Skip: skipGpuPlugin},
 	}
 }
 

--- a/pkg/windows/tasks.go
+++ b/pkg/windows/tasks.go
@@ -256,8 +256,6 @@ func (i *InstallTerminus) Execute(runtime connector.Runtime) error {
 	var envs = []string{
 		fmt.Sprintf("export %s=%s", common.ENV_KUBE_TYPE, i.KubeConf.Arg.Kubetype),
 		fmt.Sprintf("export %s=%s", common.ENV_REGISTRY_MIRRORS, i.KubeConf.Arg.RegistryMirrors),
-		fmt.Sprintf("export %s=%d", common.ENV_LOCAL_GPU_ENABLE, utils.FormatBoolToInt(i.KubeConf.Arg.GPU.Enable)),
-		fmt.Sprintf("export %s=%d", common.ENV_LOCAL_GPU_SHARE, utils.FormatBoolToInt(i.KubeConf.Arg.GPU.Share)),
 		fmt.Sprintf("export %s=%s", common.ENV_CLOUDFLARE_ENABLE, i.KubeConf.Arg.Cloudflare.Enable),
 		fmt.Sprintf("export %s=%s", common.ENV_FRP_ENABLE, i.KubeConf.Arg.Frp.Enable),
 		fmt.Sprintf("export %s=%s", common.ENV_FRP_SERVER, i.KubeConf.Arg.Frp.Server),


### PR DESCRIPTION
Install Olares in WSL, with GPU-related components installed by default, without relying on parameters set in environment variables.