### PR TITLE
fix: add precheck for port 9100

### DIFF
--- a/pkg/bootstrap/precheck/tasks.go
+++ b/pkg/bootstrap/precheck/tasks.go
@@ -57,7 +57,7 @@ type PreCheckPortsBindable struct {
 }
 
 func (t *PreCheckPortsBindable) Execute(runtime connector.Runtime) error {
-	ports := []int{80, 443, 444, 2444, 30180}
+	ports := []int{80, 443, 444, 2444, 9100, 30180}
 	var unbindablePorts []int
 	for _, port := range ports {
 		l, err := net.Listen("tcp", fmt.Sprintf(":%d", port))


### PR DESCRIPTION
port 9100 in host network is required by the node exporter.