### PR TITLE
feat: seperate phase & command for storage installation

### DIFF
--- a/cmd/ctl/options/cli_options.go
+++ b/cmd/ctl/options/cli_options.go
@@ -30,6 +30,7 @@ func (o *CliTerminusUninstallOptions) AddFlags(cmd *cobra.Command) {
 type CliTerminusInstallOptions struct {
 	Version         string
 	KubeType        string
+	WithJuiceFS     bool
 	MiniKubeProfile string
 	BaseDir         string
 }
@@ -41,6 +42,7 @@ func NewCliTerminusInstallOptions() *CliTerminusInstallOptions {
 func (o *CliTerminusInstallOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&o.Version, "version", "v", "", "Set Olares version, e.g., 1.10.0, 1.10.0-20241109")
 	cmd.Flags().StringVar(&o.KubeType, "kube", "k3s", "Set kube type, e.g., k3s or k8s")
+	cmd.Flags().BoolVar(&o.WithJuiceFS, "with-juicefs", false, "Use JuiceFS as the rootfs for Olares workloads, rather than the local disk.")
 	cmd.Flags().StringVarP(&o.MiniKubeProfile, "profile", "p", "", "Set Minikube profile name, only in MacOS platform, defaults to "+common.MinikubeDefaultProfile)
 	cmd.Flags().StringVarP(&o.BaseDir, "base-dir", "b", "", "Set Olares package base dir, defaults to $HOME/"+cc.DefaultBaseDir)
 }
@@ -51,7 +53,6 @@ type CliPrepareSystemOptions struct {
 	RegistryMirrors string
 	BaseDir         string
 	MinikubeProfile string
-	WithJuiceFS     bool
 }
 
 func NewCliPrepareSystemOptions() *CliPrepareSystemOptions {
@@ -64,7 +65,6 @@ func (o *CliPrepareSystemOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&o.RegistryMirrors, "registry-mirrors", "r", "", "Docker Container registry mirrors, multiple mirrors are separated by commas")
 	cmd.Flags().StringVarP(&o.BaseDir, "base-dir", "b", "", "Set Olares package base dir, defaults to $HOME/"+cc.DefaultBaseDir)
 	cmd.Flags().StringVarP(&o.MinikubeProfile, "profile", "p", "", "Set Minikube profile name, only in MacOS platform, defaults to "+common.MinikubeDefaultProfile)
-	cmd.Flags().BoolVar(&o.WithJuiceFS, "with-juicefs", false, "Use JuiceFS as the rootfs for Olares workloads, rather than the local disk.")
 }
 
 type ChangeIPOptions struct {
@@ -83,4 +83,18 @@ func (o *ChangeIPOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&o.BaseDir, "base-dir", "b", "", "Set Olares package base dir, defaults to $HOME/"+cc.DefaultBaseDir)
 	cmd.Flags().StringVarP(&o.WSLDistribution, "distribution", "d", "", "Set WSL distribution name, only in Windows platform, defaults to "+common.WSLDefaultDistribution)
 	cmd.Flags().StringVarP(&o.MinikubeProfile, "profile", "p", "", "Set Minikube profile name, only in MacOS platform, defaults to "+common.MinikubeDefaultProfile)
+}
+
+type InstallStorageOptions struct {
+	Version string
+	BaseDir string
+}
+
+func NewInstallStorageOptions() *InstallStorageOptions {
+	return &InstallStorageOptions{}
+}
+
+func (o *InstallStorageOptions) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&o.Version, "version", "v", "", "Set Olares version, e.g., 1.10.0, 1.10.0-20241109")
+	cmd.Flags().StringVarP(&o.BaseDir, "base-dir", "b", "", "Set Olares package base dir, defaults to $HOME/"+cc.DefaultBaseDir)
 }

--- a/cmd/ctl/os/install.go
+++ b/cmd/ctl/os/install.go
@@ -29,5 +29,6 @@ func NewCmdInstallOs() *cobra.Command {
 		},
 	}
 	o.InstallOptions.AddFlags(cmd)
+	cmd.AddCommand(NewCmdInstallStorage())
 	return cmd
 }

--- a/cmd/ctl/os/storage.go
+++ b/cmd/ctl/os/storage.go
@@ -1,0 +1,24 @@
+package os
+
+import (
+	"bytetrade.io/web3os/installer/cmd/ctl/options"
+	"bytetrade.io/web3os/installer/pkg/pipelines"
+	"github.com/spf13/cobra"
+	"log"
+)
+
+func NewCmdInstallStorage() *cobra.Command {
+	o := options.NewInstallStorageOptions()
+	cmd := &cobra.Command{
+		Use:   "storage",
+		Short: "install a storage backend for the Olares shared filesystem, or in the case of external storage, validate the config",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := pipelines.CliInstallStoragePipeline(o); err != nil {
+				log.Fatalf("error: %v", err)
+			}
+		},
+	}
+	o.AddFlags(cmd)
+
+	return cmd
+}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -159,7 +159,10 @@ const (
 	OSS   = "oss"
 	COS   = "cos"
 	S3    = "s3"
-	Minio = "minio"
+	MinIO = "minio"
+
+	//ManagedMinIO is MinIO instance that's managed by us
+	ManagedMinIO = "managed-minio"
 )
 
 var (

--- a/pkg/common/kube_runtime.go
+++ b/pkg/common/kube_runtime.go
@@ -181,7 +181,7 @@ func NewArgument() *Argument {
 		SystemInfo:       connector.GetSystemInfo(),
 		IsCloudInstance:  strings.EqualFold(os.Getenv(ENV_TERMINUS_IS_CLOUD_VERSION), TRUE),
 		Storage: &Storage{
-			StorageType: Minio,
+			StorageType: ManagedMinIO,
 		},
 		GPU: &GPU{
 			Enable: strings.EqualFold(os.Getenv(ENV_LOCAL_GPU_ENABLE), "1"),

--- a/pkg/phase/cluster/utils.go
+++ b/pkg/phase/cluster/utils.go
@@ -35,3 +35,16 @@ func (m backupModuleBuilder) withBackup(runtime *common.KubeRuntime) []module.Mo
 	}
 	return nil
 }
+
+type fsModuleBuilder func() []module.Module
+
+func (m fsModuleBuilder) withJuiceFS(runtime *common.KubeRuntime) []module.Module {
+	// if juicefs is enabled
+	// install redis/juicefs
+	if runtime.Arg.WithJuiceFS {
+		return m()
+	}
+	// use local fs
+	// so nothing need to be done
+	return nil
+}

--- a/pkg/phase/system/linux.go
+++ b/pkg/phase/system/linux.go
@@ -46,30 +46,6 @@ func (l *linuxPhaseBuilder) base() phase {
 	return m
 }
 
-func (l *linuxPhaseBuilder) storage() phase {
-	return []module.Module{
-		&storage.InstallMinioModule{
-			ManifestModule: manifest.ManifestModule{
-				Manifest: l.manifestMap,
-				BaseDir:  l.runtime.GetBaseDir(), // l.runtime.Arg.BaseDir,
-			},
-			Skip: l.runtime.Arg.Storage.StorageType != common.Minio,
-		},
-		&storage.InstallRedisModule{
-			ManifestModule: manifest.ManifestModule{
-				Manifest: l.manifestMap,
-				BaseDir:  l.runtime.GetBaseDir(), // l.runtime.Arg.BaseDir,
-			},
-		},
-		&storage.InstallJuiceFsModule{
-			ManifestModule: manifest.ManifestModule{
-				Manifest: l.manifestMap,
-				BaseDir:  l.runtime.GetBaseDir(), // l.runtime.Arg.BaseDir,
-			},
-		},
-	}
-}
-
 func (l *linuxPhaseBuilder) installContainerModule() []module.Module {
 	var isK3s = strings.Contains(l.runtime.Arg.KubernetesVersion, "k3s")
 	if isK3s {
@@ -101,10 +77,6 @@ func (l *linuxPhaseBuilder) build() []module.Module {
 				&storage.InitStorageModule{Skip: !l.runtime.Arg.IsCloudInstance},
 			}
 		}).withCloud(l.runtime)...).
-		addModule(storageModuleBuilder(func() []module.Module {
-			return l.storage()
-
-		}).withJuiceFS(l.runtime)...).
 		addModule(cloudModuleBuilder(l.installContainerModule).withoutCloud(l.runtime)...).
 		addModule(cloudModuleBuilder(func() []module.Module {
 			// unitl now, system ready

--- a/pkg/phase/system/storage.go
+++ b/pkg/phase/system/storage.go
@@ -1,0 +1,42 @@
+package system
+
+import (
+	"bytetrade.io/web3os/installer/pkg/common"
+	"bytetrade.io/web3os/installer/pkg/core/logger"
+	"bytetrade.io/web3os/installer/pkg/core/module"
+	"bytetrade.io/web3os/installer/pkg/core/pipeline"
+	"bytetrade.io/web3os/installer/pkg/manifest"
+	"bytetrade.io/web3os/installer/pkg/storage"
+	"os"
+)
+
+func InstallStoragePipeline(runtime *common.KubeRuntime) *pipeline.Pipeline {
+	si := runtime.GetSystemInfo()
+	if si.IsDarwin() || si.IsWindows() {
+		logger.Infof("storage is supposed to be installed on Linux, no operation will be done on %s", si.GetOsType())
+		os.Exit(0)
+	}
+	var modules []module.Module
+	manifestMap, err := manifest.ReadAll(runtime.Arg.Manifest)
+	if err != nil {
+		logger.Fatal(err)
+	}
+	modules = []module.Module{
+		&storage.ValidateModule{
+			Skip: runtime.Arg.Storage.StorageType == common.ManagedMinIO,
+		},
+		&storage.InstallMinioModule{
+			ManifestModule: manifest.ManifestModule{
+				Manifest: manifestMap,
+				BaseDir:  runtime.GetBaseDir(), // l.runtime.Arg.BaseDir,
+			},
+			Skip: runtime.Arg.Storage.StorageType != common.ManagedMinIO,
+		},
+	}
+
+	return &pipeline.Pipeline{
+		Name:    "Install Storage",
+		Modules: modules,
+		Runtime: runtime,
+	}
+}

--- a/pkg/phase/system/utils.go
+++ b/pkg/phase/system/utils.go
@@ -39,19 +39,6 @@ func (m cloudModuleBuilder) withoutCloud(runtime *common.KubeRuntime) []module.M
 	return nil
 }
 
-type storageModuleBuilder func() []module.Module
-
-func (m storageModuleBuilder) withJuiceFS(runtime *common.KubeRuntime) []module.Module {
-	// if juicefs is enabled
-	// install redis/minio/juicefs
-	if runtime.Arg.WithJuiceFS {
-		return m()
-	}
-	// use local disk storage
-	// so nothing need to be done
-	return nil
-}
-
 type gpuModuleBuilder func() []module.Module
 
 func (m gpuModuleBuilder) withGPU(runtime *common.KubeRuntime) []module.Module {

--- a/pkg/pipelines/install_terminus.go
+++ b/pkg/pipelines/install_terminus.go
@@ -30,7 +30,9 @@ func CliInstallTerminusPipeline(opts *options.CliTerminusInstallOptions) error {
 	arg.SetStorage(getStorageValueFromEnv())
 	arg.SetReverseProxy()
 	arg.SetTokenMaxAge()
-
+	if opts.WithJuiceFS {
+		arg.WithJuiceFS = true
+	}
 	runtime, err := common.NewKubeRuntime(common.AllInOne, *arg)
 	if err != nil {
 		return fmt.Errorf("error creating runtime: %v", err)

--- a/pkg/pipelines/prepare_system.go
+++ b/pkg/pipelines/prepare_system.go
@@ -28,9 +28,6 @@ func PrepareSystemPipeline(opts *options.CliPrepareSystemOptions) error {
 	arg.SetStorage(getStorageValueFromEnv())
 	arg.SetTokenMaxAge()
 	arg.SetReverseProxy()
-	if opts.WithJuiceFS {
-		arg.WithJuiceFS = true
-	}
 
 	runtime, err := common.NewKubeRuntime(common.AllInOne, *arg)
 	if err != nil {
@@ -50,11 +47,10 @@ func PrepareSystemPipeline(opts *options.CliPrepareSystemOptions) error {
 }
 
 func getStorageValueFromEnv() *common.Storage {
-	storageType := os.Getenv("STORAGE")
+	storageType := os.Getenv(common.ENV_STORAGE)
 	switch storageType {
-	case common.S3, common.OSS, common.COS:
-	default:
-		storageType = common.Minio
+	case "":
+		storageType = common.ManagedMinIO
 	}
 
 	return &common.Storage{

--- a/pkg/pipelines/storage.go
+++ b/pkg/pipelines/storage.go
@@ -1,0 +1,33 @@
+package pipelines
+
+import (
+	"bytetrade.io/web3os/installer/cmd/ctl/options"
+	"bytetrade.io/web3os/installer/pkg/common"
+	"bytetrade.io/web3os/installer/pkg/phase"
+	"bytetrade.io/web3os/installer/pkg/phase/system"
+	"fmt"
+	"github.com/pkg/errors"
+	"path"
+)
+
+func CliInstallStoragePipeline(opts *options.InstallStorageOptions) error {
+	var terminusVersion, _ = phase.GetTerminusVersion()
+	if terminusVersion != "" {
+		return errors.New("Olares is already installed, please uninstall it first.")
+	}
+
+	arg := common.NewArgument()
+	arg.SetBaseDir(opts.BaseDir)
+	arg.SetTerminusVersion(opts.Version)
+	arg.SetStorage(getStorageValueFromEnv())
+
+	runtime, err := common.NewKubeRuntime(common.AllInOne, *arg)
+	if err != nil {
+		return fmt.Errorf("error creating runtime: %v", err)
+	}
+
+	manifest := path.Join(runtime.GetInstallerDir(), "installation.manifest")
+	runtime.Arg.SetManifest(manifest)
+
+	return system.InstallStoragePipeline(runtime).Start()
+}

--- a/pkg/storage/module.go
+++ b/pkg/storage/module.go
@@ -114,17 +114,6 @@ type RemoveStorageModule struct {
 func (m *RemoveStorageModule) Init() {
 	m.Name = "RemoveStorage"
 
-	stopJuiceFS := &task.RemoteTask{
-		Name:  "StopJuiceFS",
-		Hosts: m.Runtime.GetHostsByRole(common.Master),
-		Prepare: &prepare.PrepareCollection{
-			new(common.OnlyFirstMaster),
-		},
-		Action:   new(StopJuiceFS),
-		Parallel: false,
-		Retry:    0,
-	}
-
 	stopMinio := &task.RemoteTask{
 		Name:  "StopMinio",
 		Hosts: m.Runtime.GetHostsByRole(common.Master),
@@ -147,17 +136,6 @@ func (m *RemoveStorageModule) Init() {
 		Retry:    0,
 	}
 
-	stopRedis := &task.RemoteTask{
-		Name:  "StopRedis",
-		Hosts: m.Runtime.GetHostsByRole(common.Master),
-		Prepare: &prepare.PrepareCollection{
-			new(common.OnlyFirstMaster),
-		},
-		Action:   new(StopRedis),
-		Parallel: false,
-		Retry:    0,
-	}
-
 	removeTerminusFiles := &task.RemoteTask{
 		Name:  "RemoveOlaresFiles",
 		Hosts: m.Runtime.GetHostsByRole(common.Master),
@@ -170,11 +148,55 @@ func (m *RemoveStorageModule) Init() {
 	}
 
 	m.Tasks = []task.Interface{
-		stopJuiceFS,
 		stopMinio,
 		stopMinioOperator,
-		stopRedis,
 		removeTerminusFiles,
+	}
+}
+
+type RemoveJuiceFSModule struct {
+	common.KubeModule
+}
+
+func (m *RemoveJuiceFSModule) Init() {
+	m.Name = "RemoveJuiceFS"
+
+	stopJuiceFS := &task.RemoteTask{
+		Name:  "StopJuiceFS",
+		Hosts: m.Runtime.GetHostsByRole(common.Master),
+		Prepare: &prepare.PrepareCollection{
+			new(common.OnlyFirstMaster),
+		},
+		Action:   new(StopJuiceFS),
+		Parallel: false,
+		Retry:    0,
+	}
+
+	stopRedis := &task.RemoteTask{
+		Name:  "StopRedis",
+		Hosts: m.Runtime.GetHostsByRole(common.Master),
+		Prepare: &prepare.PrepareCollection{
+			new(common.OnlyFirstMaster),
+		},
+		Action:   new(StopRedis),
+		Parallel: false,
+		Retry:    0,
+	}
+
+	removeJuiceFSFiles := &task.RemoteTask{
+		Name:  "RemoveJuiceFSFiles",
+		Hosts: m.Runtime.GetHostsByRole(common.Master),
+		Prepare: &prepare.PrepareCollection{
+			new(common.OnlyFirstMaster),
+		},
+		Action:   new(RemoveJuiceFSFiles),
+		Parallel: false,
+		Retry:    0,
+	}
+	m.Tasks = []task.Interface{
+		stopJuiceFS,
+		stopRedis,
+		removeJuiceFSFiles,
 	}
 }
 

--- a/pkg/storage/tasks.go
+++ b/pkg/storage/tasks.go
@@ -268,23 +268,38 @@ func (t *StopRedis) Execute(runtime connector.Runtime) error {
 	return nil
 }
 
-type RemoveTerminusFiles struct {
+type RemoveJuiceFSFiles struct {
 	common.KubeAction
 }
 
-func (t *RemoveTerminusFiles) Execute(runtime connector.Runtime) error {
+func (t *RemoveJuiceFSFiles) Execute(runtime connector.Runtime) error {
 	var files = []string{
 		"/usr/local/bin/redis-*",
 		"/usr/bin/redis-*",
 		"/sbin/mount.juicefs",
 		"/etc/init.d/redis-server",
 		"/usr/local/bin/juicefs",
+		"/etc/systemd/system/redis-server.service",
+		"/etc/systemd/system/juicefs.service",
+	}
+
+	for _, f := range files {
+		runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("rm -rf %s", f), false, true)
+	}
+
+	return nil
+}
+
+type RemoveTerminusFiles struct {
+	common.KubeAction
+}
+
+func (t *RemoveTerminusFiles) Execute(runtime connector.Runtime) error {
+	var files = []string{
 		"/usr/local/bin/minio",
 		"/usr/local/bin/velero",
-		"/etc/systemd/system/redis-server.service",
 		"/etc/systemd/system/minio.service",
 		"/etc/systemd/system/minio-operator.service",
-		"/etc/systemd/system/juicefs.service",
 	}
 
 	for _, f := range files {

--- a/pkg/storage/validate.go
+++ b/pkg/storage/validate.go
@@ -1,0 +1,44 @@
+package storage
+
+import (
+	"bytetrade.io/web3os/installer/pkg/common"
+	"bytetrade.io/web3os/installer/pkg/core/connector"
+	"bytetrade.io/web3os/installer/pkg/core/task"
+	"fmt"
+)
+
+type ValidateModule struct {
+	common.KubeModule
+	Skip bool
+}
+
+func (m *ValidateModule) IsSkip() bool {
+	return m.Skip
+}
+
+func (m *ValidateModule) Init() {
+	m.Name = "ValidateStorageConfig"
+
+	m.Tasks = append(m.Tasks, &task.LocalTask{
+		Name:   "ValidateStorageConfig",
+		Action: new(ValidateStorageConfig),
+	})
+}
+
+type ValidateStorageConfig struct {
+	common.KubeAction
+}
+
+func (a *ValidateStorageConfig) Execute(runtime connector.Runtime) error {
+	storageConf := a.KubeConf.Arg.Storage
+	if storageConf.StorageBucket == "" {
+		return fmt.Errorf("missing storage bucket, please set it in env %s", common.ENV_S3_BUCKET)
+	}
+	if storageConf.StorageAccessKey == "" {
+		return fmt.Errorf("missing storage access key, please set it in env %s", common.ENV_AWS_ACCESS_KEY_ID_SETUP)
+	}
+	if storageConf.StorageSecretKey == "" {
+		return fmt.Errorf("missing storage secret key, please set it in env %s", common.ENV_AWS_SECRET_ACCESS_KEY_SETUP)
+	}
+	return nil
+}


### PR DESCRIPTION
- tasks related to object storage installation are moved out of `prepare` phase into a separate `install storage` phase
- a MinIO instance managed by Olares will be installed as object storage service, if no external storage service is specified
- configs must be provided if external storage service is specified, this is validated in the `install storage` phase
- tasks and options related to JuiceFS and its dependency Redis are moved out of `prepare` phase into the `install` phase
- a `storage` phase between `install` and `prepare` is added into the `uninstall` command