### PR TITLE
fix: reset config path of cri plugin in minikube

### DIFF
--- a/pkg/kubesphere/minikube.go
+++ b/pkg/kubesphere/minikube.go
@@ -122,6 +122,12 @@ func (t *SetMirrorsToMinikubeContainerdConfig) Execute(runtime connector.Runtime
 	if !ok {
 		return fmt.Errorf("failed to load minikube containerd cri plugin config: decoded type mismatch")
 	}
+	if criPluginConfig.Registry.ConfigPath != "" {
+		// reset config path as it will mask the other options
+		// we do not set mirrors in the config path
+		// because image-service expects an explicit inline config in the Mirrors field
+		criPluginConfig.Registry.ConfigPath = ""
+	}
 	if criPluginConfig.Registry.Mirrors == nil {
 		criPluginConfig.Registry.Mirrors = make(map[string]criconfig.Mirror)
 	}


### PR DESCRIPTION
If the `config_path` is set in the `[plugins."io.containerd.grpc.v1.cri".registry]` section in containerd config, the `[plugins."io.containerd.grpc.v1.cri".registry.mirrors]` will take no effect, so the `config_path` should be reset if we need to inject mirrors to the containerd config in MiniKube.