### PR TITLE
feat: add windows firewall rule

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -284,6 +284,7 @@ const (
 	ENV_HOST_IP                     = "HOST_IP"
 	ENV_PREINSTALL                  = "PREINSTALL"
 	ENV_DISABLE_HOST_IP_PROMPT      = "DISABLE_HOST_IP_PROMPT"
+	ENV_AUTO_ADD_FIREWALL_RULES     = "AUTO_ADD_FIREWALL_RULES"
 )
 
 // TerminusGlobalEnvs holds a group of general environment variables

--- a/pkg/windows/modules.go
+++ b/pkg/windows/modules.go
@@ -68,10 +68,16 @@ func (c *ConfigWslModule) Init() {
 		Action: &ConfigWSLHostsAndDns{},
 	}
 
+	configWindowsFirewallRule := &task.LocalTask{
+		Name:   "ConfigFirewallRule",
+		Action: &ConfigWindowsFirewallRule{},
+	}
+
 	c.Tasks = []task.Interface{
 		configWslConf,
 		configWSLForwardRules,
 		configWSLHostsAndDns,
+		configWindowsFirewallRule,
 	}
 }
 
@@ -99,6 +105,14 @@ func (u *UninstallOlaresModule) Init() {
 		&task.LocalTask{
 			Name:   "UninstallOlares",
 			Action: &UninstallOlares{},
+		},
+		&task.LocalTask{
+			Name:   "RemoveFirewallRule",
+			Action: &RemoveFirewallRule{},
+		},
+		&task.LocalTask{
+			Name:   "RemovePortProxy",
+			Action: &RemovePortProxy{},
 		},
 	}
 }


### PR DESCRIPTION
install WSL to add the operation for setting firewall inbound rules.
- prompting the user whether to allow adding firewall rules to allow TCP protocol ports including 80, 443, and 30180. 
- If the Windows environment variable AUTO_ADD_FIREWALL_RULES is set to any value, the firewall rules will be automatically added.