### PR TITLE
fix: filter out p2p network interfaces when detecting machine IP

### DIFF
--- a/pkg/terminus/settings.go
+++ b/pkg/terminus/settings.go
@@ -43,7 +43,7 @@ func (p *SetSettingsValues) Execute(runtime connector.Runtime) error {
 	}
 
 	publicNetworkInfo := p.KubeConf.Arg.PublicNetworkInfo
-	if len(publicNetworkInfo.OSPublicIPs) > 0 || publicNetworkInfo.AWSPublicIP != nil {
+	if publicNetworkInfo.AWSPublicIP != nil {
 		selfhosted = false
 	}
 


### PR DESCRIPTION
Some VPN services, e.g., tailscale, may set up a network device on the system which has a false public IP address.
The `PointToPoint` flag is set, and can be used to filter out such devices.