### PR TITLE
feat: add worker node to the cluster

### DIFF
--- a/cmd/ctl/node/masterinfo.go
+++ b/cmd/ctl/node/masterinfo.go
@@ -7,13 +7,13 @@ import (
 	"log"
 )
 
-func NewCmdAddNode() *cobra.Command {
-	o := options.NewAddNodeOptions()
+func NewCmdMasterInfo() *cobra.Command {
+	o := options.NewMasterInfoOptions()
 	cmd := &cobra.Command{
-		Use:   "add",
-		Short: "add worker node to the cluster",
+		Use:   "masterinfo",
+		Short: "get information about master node, and check whether current node can be added to the cluster",
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := pipelines.AddNodePipeline(o); err != nil {
+			if err := pipelines.MasterInfoPipeline(o); err != nil {
 				log.Fatal(err)
 			}
 		},

--- a/cmd/ctl/node/root.go
+++ b/cmd/ctl/node/root.go
@@ -1,0 +1,13 @@
+package node
+
+import "github.com/spf13/cobra"
+
+func NewNodeCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "node",
+		Short: "cluster node related operations",
+	}
+	cmd.AddCommand(NewCmdMasterInfo())
+	cmd.AddCommand(NewCmdAddNode())
+	return cmd
+}

--- a/cmd/ctl/options/cli_options.go
+++ b/cmd/ctl/options/cli_options.go
@@ -70,6 +70,7 @@ func (o *CliPrepareSystemOptions) AddFlags(cmd *cobra.Command) {
 type ChangeIPOptions struct {
 	Version         string
 	BaseDir         string
+	NewMasterHost   string
 	WSLDistribution string
 	MinikubeProfile string
 }
@@ -81,6 +82,7 @@ func NewChangeIPOptions() *ChangeIPOptions {
 func (o *ChangeIPOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&o.Version, "version", "v", "", "Set Olares version, e.g., 1.10.0, 1.10.0-20241109")
 	cmd.Flags().StringVarP(&o.BaseDir, "base-dir", "b", "", "Set Olares package base dir, defaults to $HOME/"+cc.DefaultBaseDir)
+	cmd.Flags().StringVar(&o.NewMasterHost, "new-master-host", "", "Update the master node's IP if it's changed, only in Linux worker node")
 	cmd.Flags().StringVarP(&o.WSLDistribution, "distribution", "d", "", "Set WSL distribution name, only in Windows platform, defaults to "+common.WSLDefaultDistribution)
 	cmd.Flags().StringVarP(&o.MinikubeProfile, "profile", "p", "", "Set Minikube profile name, only in MacOS platform, defaults to "+common.MinikubeDefaultProfile)
 }
@@ -111,4 +113,34 @@ func NewInstallStorageOptions() *InstallStorageOptions {
 func (o *InstallStorageOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&o.Version, "version", "v", "", "Set Olares version, e.g., 1.10.0, 1.10.0-20241109")
 	cmd.Flags().StringVarP(&o.BaseDir, "base-dir", "b", "", "Set Olares package base dir, defaults to $HOME/"+cc.DefaultBaseDir)
+}
+
+type AddNodeOptions struct {
+	common.MasterHostConfig
+	Version string
+	BaseDir string
+}
+
+func NewAddNodeOptions() *AddNodeOptions {
+	return &AddNodeOptions{}
+}
+
+func (o *AddNodeOptions) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&o.Version, "version", "v", "", "Set Olares version, e.g., 1.10.0, 1.10.0-20241109")
+	cmd.Flags().StringVarP(&o.BaseDir, "base-dir", "b", "", "Set Olares package base dir, defaults to $HOME/"+cc.DefaultBaseDir)
+	(&o.MasterHostConfig).AddFlags(cmd.Flags())
+}
+
+type MasterInfoOptions struct {
+	BaseDir string
+	common.MasterHostConfig
+}
+
+func NewMasterInfoOptions() *MasterInfoOptions {
+	return &MasterInfoOptions{}
+}
+
+func (o *MasterInfoOptions) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&o.BaseDir, "base-dir", "b", "", "Set Olares package base dir, defaults to $HOME/"+cc.DefaultBaseDir)
+	(&o.MasterHostConfig).AddFlags(cmd.Flags())
 }

--- a/cmd/ctl/root.go
+++ b/cmd/ctl/root.go
@@ -3,6 +3,7 @@ package ctl
 import (
 	"bytetrade.io/web3os/installer/cmd/ctl/gpu"
 	"bytetrade.io/web3os/installer/cmd/ctl/info"
+	"bytetrade.io/web3os/installer/cmd/ctl/node"
 	"bytetrade.io/web3os/installer/cmd/ctl/os"
 	"bytetrade.io/web3os/installer/version"
 	"github.com/spf13/cobra"
@@ -18,6 +19,7 @@ func NewDefaultCommand() *cobra.Command {
 
 	cmds.AddCommand(info.NewCmdInfo())
 	cmds.AddCommand(os.NewCmdOs())
+	cmds.AddCommand(node.NewNodeCommand())
 	cmds.AddCommand(gpu.NewCmdGpu())
 
 	return cmds

--- a/pkg/binaries/prepares.go
+++ b/pkg/binaries/prepares.go
@@ -23,7 +23,7 @@ func (p *Ubuntu24AppArmorCheck) PreCheck(runtime connector.Runtime) (bool, error
 	}
 
 	cmd := "apparmor_parser --version"
-	stdout, err := runtime.GetRunner().Host.SudoCmd(cmd, false, true)
+	stdout, err := runtime.GetRunner().SudoCmd(cmd, false, true)
 	if err != nil {
 		logger.Errorf("check apparmor version error %v", err)
 		return false, nil

--- a/pkg/binaries/tasks.go
+++ b/pkg/binaries/tasks.go
@@ -37,7 +37,7 @@ func (t *InstallAppArmorTask) Execute(runtime connector.Runtime) error {
 		logger.Fatal("failed to download apparmor: %v", err)
 	}
 
-	if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("dpkg -i %s", fileName), false, true); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("dpkg -i %s", fileName), false, true); err != nil {
 		logger.Errorf("failed to install apparmor: %v", err)
 		return err
 	}

--- a/pkg/bootstrap/download/tasks.go
+++ b/pkg/bootstrap/download/tasks.go
@@ -114,7 +114,10 @@ func (d *CheckDownload) Execute(runtime connector.Runtime) error {
 func isRealExists(runtime connector.Runtime, item *manifest.ManifestItem, baseDir string) (bool, error) {
 	arch := runtime.GetSystemInfo().GetOsArch()
 	targetPath := getDownloadTargetPath(item, baseDir)
-	exists := runtime.GetRunner().Host.FileExist(targetPath)
+	exists, err := runtime.GetRunner().FileExist(targetPath)
+	if err != nil {
+		return false, err
+	}
 	if !exists {
 		return false, nil
 	}
@@ -140,7 +143,7 @@ func (d *PackageDownload) downloadItem(runtime connector.Runtime, baseDir string
 
 	downloadPath := component.Path()
 	if utils.IsExist(downloadPath) {
-		_, _ = runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("rm -rf %s", downloadPath), false, false)
+		_, _ = runtime.GetRunner().SudoCmd(fmt.Sprintf("rm -rf %s", downloadPath), false, false)
 	}
 
 	if !utils.IsExist(component.BaseDir) {

--- a/pkg/bootstrap/os/repository/repository_deb.go
+++ b/pkg/bootstrap/os/repository/repository_deb.go
@@ -32,15 +32,15 @@ func NewDeb() Interface {
 }
 
 func (d *Debian) Backup(runtime connector.Runtime) error {
-	if _, err := runtime.GetRunner().Host.SudoCmd("mv /etc/apt/sources.list /etc/apt/sources.list.kubekey.bak", false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd("mv /etc/apt/sources.list /etc/apt/sources.list.kubekey.bak", false, false); err != nil {
 		return err
 	}
 
-	if _, err := runtime.GetRunner().Host.SudoCmd("mv /etc/apt/sources.list.d /etc/apt/sources.list.d.kubekey.bak", false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd("mv /etc/apt/sources.list.d /etc/apt/sources.list.d.kubekey.bak", false, false); err != nil {
 		return err
 	}
 
-	if _, err := runtime.GetRunner().Host.SudoCmd("mkdir -p /etc/apt/sources.list.d", false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd("mkdir -p /etc/apt/sources.list.d", false, false); err != nil {
 		return err
 	}
 	d.backup = true
@@ -56,11 +56,11 @@ func (d *Debian) Add(runtime connector.Runtime, path string) error {
 		return fmt.Errorf("linux repository must be backuped before")
 	}
 
-	if _, err := runtime.GetRunner().Host.SudoCmd("rm -rf /etc/apt/sources.list.d/*", false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd("rm -rf /etc/apt/sources.list.d/*", false, false); err != nil {
 		return err
 	}
 
-	if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("echo 'deb [trusted=yes]  file://%s   /' > /etc/apt/sources.list.d/kubekey.list", path),
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("echo 'deb [trusted=yes]  file://%s   /' > /etc/apt/sources.list.d/kubekey.list", path),
 		true, false); err != nil {
 		return err
 	}
@@ -68,7 +68,7 @@ func (d *Debian) Add(runtime connector.Runtime, path string) error {
 }
 
 func (d *Debian) Update(runtime connector.Runtime) error {
-	if _, err := runtime.GetRunner().Host.Cmd("sudo apt-get update", true, false); err != nil {
+	if _, err := runtime.GetRunner().Cmd("sudo apt-get update", true, false); err != nil {
 		return err
 	}
 	return nil
@@ -83,22 +83,22 @@ func (d *Debian) Install(runtime connector.Runtime, pkg ...string) error {
 	}
 
 	str := strings.Join(pkg, " ")
-	if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("apt install -y %s", str), true, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("apt install -y %s", str), true, false); err != nil {
 		return err
 	}
 	return nil
 }
 
 func (d *Debian) Reset(runtime connector.Runtime) error {
-	if _, err := runtime.GetRunner().Host.SudoCmd("rm -rf /etc/apt/sources.list.d", false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd("rm -rf /etc/apt/sources.list.d", false, false); err != nil {
 		return err
 	}
 
-	if _, err := runtime.GetRunner().Host.SudoCmd("mv /etc/apt/sources.list.kubekey.bak /etc/apt/sources.list", false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd("mv /etc/apt/sources.list.kubekey.bak /etc/apt/sources.list", false, false); err != nil {
 		return err
 	}
 
-	if _, err := runtime.GetRunner().Host.SudoCmd("mv /etc/apt/sources.list.d.kubekey.bak /etc/apt/sources.list.d", false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd("mv /etc/apt/sources.list.d.kubekey.bak /etc/apt/sources.list.d", false, false); err != nil {
 		return err
 	}
 

--- a/pkg/bootstrap/os/repository/repository_rpm.go
+++ b/pkg/bootstrap/os/repository/repository_rpm.go
@@ -32,11 +32,11 @@ func NewRPM() Interface {
 }
 
 func (r *RedhatPackageManager) Backup(runtime connector.Runtime) error {
-	if _, err := runtime.GetRunner().Host.SudoCmd("mv /etc/yum.repos.d /etc/yum.repos.d.kubekey.bak", false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd("mv /etc/yum.repos.d /etc/yum.repos.d.kubekey.bak", false, false); err != nil {
 		return err
 	}
 
-	if _, err := runtime.GetRunner().Host.SudoCmd("mkdir -p /etc/yum.repos.d", false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd("mkdir -p /etc/yum.repos.d", false, false); err != nil {
 		return err
 	}
 	r.backup = true
@@ -52,7 +52,7 @@ func (r *RedhatPackageManager) Add(runtime connector.Runtime, path string) error
 		return fmt.Errorf("linux repository must be backuped before")
 	}
 
-	if _, err := runtime.GetRunner().Host.SudoCmd("rm -rf /etc/yum.repos.d/*", false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd("rm -rf /etc/yum.repos.d/*", false, false); err != nil {
 		return err
 	}
 
@@ -68,7 +68,7 @@ gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 EOF
 `, path)
-	if _, err := runtime.GetRunner().Host.SudoCmd(content, false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(content, false, false); err != nil {
 		return err
 	}
 
@@ -76,7 +76,7 @@ EOF
 }
 
 func (r *RedhatPackageManager) Update(runtime connector.Runtime) error {
-	if _, err := runtime.GetRunner().Host.SudoCmd("yum clean all && yum makecache", true, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd("yum clean all && yum makecache", true, false); err != nil {
 		return err
 	}
 	return nil
@@ -91,18 +91,18 @@ func (r *RedhatPackageManager) Install(runtime connector.Runtime, pkg ...string)
 	}
 
 	str := strings.Join(pkg, " ")
-	if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("yum install -y %s", str), true, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("yum install -y %s", str), true, false); err != nil {
 		return err
 	}
 	return nil
 }
 
 func (r *RedhatPackageManager) Reset(runtime connector.Runtime) error {
-	if _, err := runtime.GetRunner().Host.SudoCmd("rm -rf /etc/yum.repos.d", false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd("rm -rf /etc/yum.repos.d", false, false); err != nil {
 		return err
 	}
 
-	if _, err := runtime.GetRunner().Host.SudoCmd("mv /etc/yum.repos.d.kubekey.bak /etc/yum.repos.d", false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd("mv /etc/yum.repos.d.kubekey.bak /etc/yum.repos.d", false, false); err != nil {
 		return err
 	}
 

--- a/pkg/bootstrap/os/rollback.go
+++ b/pkg/bootstrap/os/rollback.go
@@ -34,7 +34,7 @@ type RollbackUmount struct {
 func (r *RollbackUmount) Execute(runtime connector.Runtime, result *ending.ActionResult) error {
 	mountPath := filepath.Join(common.TmpDir, "iso")
 	umountCmd := fmt.Sprintf("umount %s", mountPath)
-	if _, err := runtime.GetRunner().Host.SudoCmd(umountCmd, false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(umountCmd, false, false); err != nil {
 		return errors.Wrapf(errors.WithStack(err), "umount %s failed", mountPath)
 	}
 	return nil
@@ -60,7 +60,7 @@ func (r *RecoverBackupSuccessNode) Execute(runtime connector.Runtime, result *en
 
 	mountPath := filepath.Join(common.TmpDir, "iso")
 	umountCmd := fmt.Sprintf("umount %s", mountPath)
-	if _, err := runtime.GetRunner().Host.SudoCmd(umountCmd, false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(umountCmd, false, false); err != nil {
 		return errors.Wrapf(errors.WithStack(err), "umount %s failed", mountPath)
 	}
 	return nil
@@ -82,7 +82,7 @@ func (r *RecoverRepository) Execute(runtime connector.Runtime, result *ending.Ac
 
 	mountPath := filepath.Join(common.TmpDir, "iso")
 	umountCmd := fmt.Sprintf("umount %s", mountPath)
-	if _, err := runtime.GetRunner().Host.SudoCmd(umountCmd, false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(umountCmd, false, false); err != nil {
 		return errors.Wrapf(errors.WithStack(err), "umount %s failed", mountPath)
 	}
 	return nil

--- a/pkg/bootstrap/os/tasks.go
+++ b/pkg/bootstrap/os/tasks.go
@@ -45,8 +45,8 @@ type PatchLxcEnvVars struct {
 
 func (p *PatchLxcEnvVars) Execute(runtime connector.Runtime) error {
 	var cmd = `sed -n '/export PATH=\"\/usr\/local\/bin:$PATH\"/p' ~/.bashrc`
-	if res, _ := runtime.GetRunner().Host.CmdExt(cmd, false, false); res == "" {
-		if _, err := runtime.GetRunner().Host.Cmd("echo 'export PATH=\"/usr/local/bin:$PATH\"' >> ~/.bashrc", false, false); err != nil {
+	if res, _ := runtime.GetRunner().Cmd(cmd, false, false); res == "" {
+		if _, err := runtime.GetRunner().Cmd("echo 'export PATH=\"/usr/local/bin:$PATH\"' >> ~/.bashrc", false, false); err != nil {
 			return err
 		}
 
@@ -71,7 +71,7 @@ func (p *PatchLxcInitScript) Execute(runtime connector.Runtime) error {
 		return errors.Wrap(errors.WithStack(err), fmt.Sprintf("write lxc patch %s failed", filePath))
 	}
 
-	_, _ = runtime.GetRunner().Host.Cmd("/etc/rc.local", false, false)
+	_, _ = runtime.GetRunner().Cmd("/etc/rc.local", false, false)
 	return nil
 }
 
@@ -80,8 +80,8 @@ type RemoveCNDomain struct {
 }
 
 func (r *RemoveCNDomain) Execute(runtime connector.Runtime) error {
-	if res, _ := runtime.GetRunner().Host.CmdExt("sed -n '/search/p' /etc/resolv.conf", false, false); res != "" {
-		if _, err := runtime.GetRunner().Host.CmdExt("sed -i '/search/d' /etc/resolv.conf", false, false); err != nil {
+	if res, _ := runtime.GetRunner().Cmd("sed -n '/search/p' /etc/resolv.conf", false, false); res != "" {
+		if _, err := runtime.GetRunner().Cmd("sed -i '/search/d' /etc/resolv.conf", false, false); err != nil {
 			return err
 		}
 	}
@@ -94,7 +94,7 @@ type PveAptUpdateSourceCheck struct {
 }
 
 func (p *PveAptUpdateSourceCheck) Execute(runtime connector.Runtime) error {
-	if _, err := runtime.GetRunner().Host.Cmd("apt-get update -qq", false, false); err != nil {
+	if _, err := runtime.GetRunner().Cmd("apt-get update -qq", false, false); err != nil {
 
 		fmt.Printf("\n\nNOTE: \nThe PVE apt-get update has failed. Please check the source repository. \n\nIf you are a Non-Enterprise user:\n1. Disable the Enterprise Repository in the PVE Control Panel.\n2. Or remove the Enterprise Repository files located in /etc/apt/sources.list.d/.\n\n\n")
 
@@ -110,7 +110,7 @@ type UpdateNtpDateTask struct {
 }
 
 func (t *UpdateNtpDateTask) Execute(runtime connector.Runtime) error {
-	if _, err := runtime.GetRunner().Host.CmdExt("apt remove unattended-upgrades -y", false, true); err != nil {
+	if _, err := runtime.GetRunner().Cmd("apt remove unattended-upgrades -y", false, true); err != nil {
 		return err
 	}
 
@@ -119,7 +119,7 @@ func (t *UpdateNtpDateTask) Execute(runtime connector.Runtime) error {
 	if systemInfo.IsUbuntu() && systemInfo.IsUbuntuVersionEqual(connector.Ubuntu24) {
 		ntpPkg += " util-linux-extra "
 	}
-	if _, err := runtime.GetRunner().Host.CmdExt(fmt.Sprintf("apt install %s -y", ntpPkg), false, true); err != nil {
+	if _, err := runtime.GetRunner().Cmd(fmt.Sprintf("apt install %s -y", ntpPkg), false, true); err != nil {
 		return err
 	}
 
@@ -128,7 +128,7 @@ func (t *UpdateNtpDateTask) Execute(runtime connector.Runtime) error {
 		return fmt.Errorf("getntpdate command error: %v", err)
 	}
 
-	if _, err := runtime.GetRunner().Host.CmdExt(fmt.Sprintf("%s -b -u pool.ntp.org", ntpdateCommand), false, true); err != nil {
+	if _, err := runtime.GetRunner().Cmd(fmt.Sprintf("%s -b -u pool.ntp.org", ntpdateCommand), false, true); err != nil {
 		return err
 	}
 
@@ -141,7 +141,7 @@ type TimeSyncTask struct {
 
 func (t *TimeSyncTask) Execute(runtime connector.Runtime) error {
 	// var cmd = `sysctl -w kernel.printk="3 3 1 7"`
-	// if _, err := runtime.GetRunner().Host.SudoCmd(cmd, false, true); err != nil {
+	// if _, err := runtime.GetRunner().SudoCmd(cmd, false, true); err != nil {
 	// 	logger.Errorf("failed to execute %s: %v", cmd, err)
 	// 	return err
 	// }
@@ -152,7 +152,7 @@ func (t *TimeSyncTask) Execute(runtime connector.Runtime) error {
 	if err != nil {
 		logger.Debugf("hwclock not found")
 	} else {
-		if _, err := runtime.GetRunner().Host.CmdExt(fmt.Sprintf("%s -w", hwclockCommand), false, true); err != nil {
+		if _, err := runtime.GetRunner().Cmd(fmt.Sprintf("%s -w", hwclockCommand), false, true); err != nil {
 			logger.Debugf("hwclock set the RTC from the system time error %v", err)
 		} else {
 			hwclockCmd = fmt.Sprintf(" && %s -w", hwclockCommand)
@@ -176,13 +176,13 @@ exit 0`, ntpdatePath, hwclockCmd)
 		return err
 	}
 
-	if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("/bin/sh %s", cronFile), false, true); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("/bin/sh %s", cronFile), false, true); err != nil {
 		logger.Errorf("failed to execute cron.ntpdate: %v", err)
 		return err
 	}
 
 	var cmd = fmt.Sprintf("cat %s > /etc/cron.daily/ntpdate && chmod 0700 /etc/cron.daily/ntpdate && rm -rf %s", cronFile, cronFile)
-	if _, err := runtime.GetRunner().Host.SudoCmd(cmd, false, true); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(cmd, false, true); err != nil {
 		logger.Errorf("failed to execute %s: %v", cmd, err)
 		return err
 	}
@@ -200,7 +200,7 @@ func (t *ConfigProxyTask) Execute(runtime connector.Runtime) error {
 	}
 
 	var cmd = fmt.Sprintf("echo nameserver %s > /etc/resolv.conf", common.ResolvProxy)
-	if _, err := runtime.GetRunner().Host.SudoCmd(cmd, false, true); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(cmd, false, true); err != nil {
 		logger.Errorf("failed to execute %s: %v", cmd, err)
 		return err
 	}
@@ -227,18 +227,18 @@ func (n *NodeConfigureOS) Execute(runtime connector.Runtime) error {
 	}
 
 	if runtime.GetSystemInfo().IsWsl() {
-		if _, err := runtime.GetRunner().Host.SudoCmd("chattr -i /etc/hosts", false, true); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd("chattr -i /etc/hosts", false, true); err != nil {
 			return errors.Wrap(err, "failed to change attributes of /etc/hosts")
 		}
 	}
 
-	_, err1 := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("hostnamectl set-hostname %s && sed -i '/^127.0.1.1/s/.*/127.0.1.1      %s/g' /etc/hosts", host.GetName(), host.GetName()), false, false)
+	_, err1 := runtime.GetRunner().SudoCmd(fmt.Sprintf("hostnamectl set-hostname %s && sed -i '/^127.0.1.1/s/.*/127.0.1.1      %s/g' /etc/hosts", host.GetName(), host.GetName()), false, false)
 	if err1 != nil {
 		return errors.Wrap(errors.WithStack(err1), "Failed to override hostname")
 	}
 
 	if runtime.GetSystemInfo().IsWsl() {
-		if _, err := runtime.GetRunner().Host.SudoCmd("chattr +i /etc/hosts", false, true); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd("chattr +i /etc/hosts", false, true); err != nil {
 			return errors.Wrap(err, "failed to change attributes of /etc/hosts")
 		}
 	}
@@ -247,12 +247,12 @@ func (n *NodeConfigureOS) Execute(runtime connector.Runtime) error {
 }
 
 func addUsers(runtime connector.Runtime, node connector.Host) error {
-	if _, err := runtime.GetRunner().Host.SudoCmd("useradd -M -c 'Kubernetes user' -s /sbin/nologin -r kube || :", false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd("useradd -M -c 'Kubernetes user' -s /sbin/nologin -r kube || :", false, false); err != nil {
 		return err
 	}
 
 	if node.IsRole(common.ETCD) {
-		if _, err := runtime.GetRunner().Host.SudoCmd("useradd -M -c 'Etcd user' -s /sbin/nologin -r etcd || :", false, false); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd("useradd -M -c 'Etcd user' -s /sbin/nologin -r etcd || :", false, false); err != nil {
 			return err
 		}
 	}
@@ -271,34 +271,34 @@ func createDirectories(runtime connector.Runtime, node connector.Host) error {
 	}
 
 	for _, dir := range dirs {
-		if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("mkdir -p %s", dir), false, false); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("mkdir -p %s", dir), false, false); err != nil {
 			return err
 		}
 		if dir == common.KubeletFlexvolumesPluginsDir {
-			if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("chown kube -R %s", "/usr/libexec/kubernetes"), false, false); err != nil {
+			if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("chown kube -R %s", "/usr/libexec/kubernetes"), false, false); err != nil {
 				return err
 			}
 		} else {
-			if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("chown kube -R %s", dir), false, false); err != nil {
+			if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("chown kube -R %s", dir), false, false); err != nil {
 				return err
 			}
 		}
 	}
 
-	if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("mkdir -p %s && chown kube -R %s", "/etc/cni/net.d", "/etc/cni"), false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("mkdir -p %s && chown kube -R %s", "/etc/cni/net.d", "/etc/cni"), false, false); err != nil {
 		return err
 	}
 
-	if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("mkdir -p %s && chown kube -R %s", "/opt/cni/bin", "/opt/cni"), false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("mkdir -p %s && chown kube -R %s", "/opt/cni/bin", "/opt/cni"), false, false); err != nil {
 		return err
 	}
 
-	if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("mkdir -p %s && chown kube -R %s", "/var/lib/calico", "/var/lib/calico"), false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("mkdir -p %s && chown kube -R %s", "/var/lib/calico", "/var/lib/calico"), false, false); err != nil {
 		return err
 	}
 
 	if node.IsRole(common.ETCD) {
-		if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("mkdir -p %s && chown etcd -R %s", "/var/lib/etcd", "/var/lib/etcd"), false, false); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("mkdir -p %s && chown etcd -R %s", "/var/lib/etcd", "/var/lib/etcd"), false, false); err != nil {
 			return err
 		}
 	}
@@ -311,11 +311,11 @@ type NodeExecScript struct {
 }
 
 func (n *NodeExecScript) Execute(runtime connector.Runtime) error {
-	if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("chmod +x %s/initOS.sh", common.KubeScriptDir), false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("chmod +x %s/initOS.sh", common.KubeScriptDir), false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "Failed to chmod +x init os script")
 	}
 
-	if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("%s/initOS.sh", common.KubeScriptDir), false, true); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("%s/initOS.sh", common.KubeScriptDir), false, true); err != nil {
 		return errors.Wrap(errors.WithStack(err), "Failed to configure operating system")
 	}
 	return nil
@@ -369,7 +369,7 @@ type ResetNetworkConfig struct {
 
 func (r *ResetNetworkConfig) Execute(runtime connector.Runtime) error {
 	for _, cmd := range networkResetCmds {
-		_, _ = runtime.GetRunner().Host.SudoCmd(cmd, false, false)
+		_, _ = runtime.GetRunner().SudoCmd(cmd, false, false)
 	}
 	return nil
 }
@@ -379,9 +379,9 @@ type UninstallETCD struct {
 }
 
 func (s *UninstallETCD) Execute(runtime connector.Runtime) error {
-	_, _ = runtime.GetRunner().Host.SudoCmd("systemctl stop etcd && exit 0", false, false)
+	_, _ = runtime.GetRunner().SudoCmd("systemctl stop etcd && exit 0", false, false)
 	for _, file := range etcdFiles {
-		_, _ = runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("rm -rf %s", file), false, false)
+		_, _ = runtime.GetRunner().SudoCmd(fmt.Sprintf("rm -rf %s", file), false, false)
 	}
 	return nil
 }
@@ -414,7 +414,7 @@ func (r *RemoveNodeFiles) Execute(runtime connector.Runtime) error {
 	}
 
 	for _, file := range nodeFiles {
-		_, _ = runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("rm -rf %s", file), false, false)
+		_, _ = runtime.GetRunner().SudoCmd(fmt.Sprintf("rm -rf %s", file), false, false)
 	}
 	return nil
 }
@@ -424,8 +424,10 @@ type RemoveClusterFiles struct {
 }
 
 func (r *RemoveClusterFiles) Execute(runtime connector.Runtime) error {
+	masterHostConfigFile := filepath.Join(runtime.GetBaseDir(), common.MasterHostConfigFile)
+	clusterFiles = append(clusterFiles, masterHostConfigFile)
 	for _, file := range clusterFiles {
-		_, _ = runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("rm -rf %s", file), false, false)
+		_, _ = runtime.GetRunner().SudoCmd(fmt.Sprintf("rm -rf %s", file), false, false)
 	}
 	return nil
 }
@@ -535,12 +537,12 @@ type DaemonReload struct {
 }
 
 func (d *DaemonReload) Execute(runtime connector.Runtime) error {
-	if _, err := runtime.GetRunner().Host.SudoCmd("systemctl daemon-reload && exit 0", false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd("systemctl daemon-reload && exit 0", false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "systemctl daemon-reload failed")
 	}
 
 	// try to restart the cotainerd after /etc/cni has been removed
-	_, _ = runtime.GetRunner().Host.SudoCmd("systemctl restart containerd", false, false)
+	_, _ = runtime.GetRunner().SudoCmd("systemctl restart containerd", false, false)
 	return nil
 }
 
@@ -549,7 +551,7 @@ type GetOSData struct {
 }
 
 func (g *GetOSData) Execute(runtime connector.Runtime) error {
-	osReleaseStr, err := runtime.GetRunner().Host.SudoCmd("cat /etc/os-release", false, false)
+	osReleaseStr, err := runtime.GetRunner().SudoCmd("cat /etc/os-release", false, false)
 	if err != nil {
 		return err
 	}
@@ -581,7 +583,7 @@ func (s *SyncRepositoryFile) Execute(runtime connector.Runtime) error {
 	fileName := fmt.Sprintf("%s-%s-%s.iso", r.ID, r.VersionID, host.GetArch())
 	src := filepath.Join(runtime.GetWorkDir(), "repository", host.GetArch(), r.ID, r.VersionID, fileName)
 	dst := filepath.Join(common.TmpDir, fileName)
-	if err := runtime.GetRunner().Host.Scp(src, dst); err != nil {
+	if err := runtime.GetRunner().Scp(src, dst); err != nil {
 		return errors.Wrapf(errors.WithStack(err), "scp %s to %s failed", src, dst)
 	}
 
@@ -595,7 +597,7 @@ type MountISO struct {
 
 func (m *MountISO) Execute(runtime connector.Runtime) error {
 	mountPath := filepath.Join(common.TmpDir, "iso")
-	if err := runtime.GetRunner().Host.MkDir(mountPath); err != nil {
+	if err := runtime.GetRunner().MkDir(mountPath); err != nil {
 		return errors.Wrapf(errors.WithStack(err), "create mount dir failed")
 	}
 
@@ -603,7 +605,7 @@ func (m *MountISO) Execute(runtime connector.Runtime) error {
 	isoFile, _ := host.GetCache().GetMustString("iso")
 	path := filepath.Join(common.TmpDir, isoFile)
 	mountCmd := fmt.Sprintf("sudo mount -t iso9660 -o loop %s %s", path, mountPath)
-	if _, err := runtime.GetRunner().Host.Cmd(mountCmd, false, false); err != nil {
+	if _, err := runtime.GetRunner().Cmd(mountCmd, false, false); err != nil {
 		return errors.Wrapf(errors.WithStack(err), "mount %s at %s failed", path, mountPath)
 	}
 	return nil
@@ -623,11 +625,11 @@ func (n *NewRepoClient) Execute(runtime connector.Runtime) error {
 
 	repo, err := repository.New(r.ID)
 	if err != nil {
-		checkDeb, debErr := runtime.GetRunner().Host.SudoCmd("which apt", false, false)
+		checkDeb, debErr := runtime.GetRunner().SudoCmd("which apt", false, false)
 		if debErr == nil && strings.Contains(checkDeb, "bin") {
 			repo = repository.NewDeb()
 		}
-		checkRPM, rpmErr := runtime.GetRunner().Host.SudoCmd("which yum", false, false)
+		checkRPM, rpmErr := runtime.GetRunner().SudoCmd("which yum", false, false)
 		if rpmErr == nil && strings.Contains(checkRPM, "bin") {
 			repo = repository.NewRPM()
 		}
@@ -726,7 +728,7 @@ func (r *ResetRepository) Execute(runtime connector.Runtime) error {
 		if resetErr != nil {
 			mountPath := filepath.Join(common.TmpDir, "iso")
 			umountCmd := fmt.Sprintf("umount %s", mountPath)
-			_, _ = runtime.GetRunner().Host.SudoCmd(umountCmd, false, false)
+			_, _ = runtime.GetRunner().SudoCmd(umountCmd, false, false)
 		}
 	}()
 
@@ -744,7 +746,7 @@ type UmountISO struct {
 func (u *UmountISO) Execute(runtime connector.Runtime) error {
 	mountPath := filepath.Join(common.TmpDir, "iso")
 	umountCmd := fmt.Sprintf("umount %s", mountPath)
-	if _, err := runtime.GetRunner().Host.SudoCmd(umountCmd, false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(umountCmd, false, false); err != nil {
 		return errors.Wrapf(errors.WithStack(err), "umount %s failed", mountPath)
 	}
 	return nil
@@ -775,7 +777,7 @@ func (n *NodeConfigureNtpServer) Execute(runtime connector.Runtime) error {
 		serverAddr := strings.Trim(server, " \"")
 		if serverAddr == currentHost.GetName() || serverAddr == currentHost.GetInternalAddress() {
 			allowClientCmd := fmt.Sprintf(`sed -i '/#allow/ a\allow 0.0.0.0/0' %s`, chronyConfigFile)
-			if _, err := runtime.GetRunner().Host.SudoCmd(allowClientCmd, false, false); err != nil {
+			if _, err := runtime.GetRunner().SudoCmd(allowClientCmd, false, false); err != nil {
 				return errors.Wrapf(err, "change host:%s chronyd conf failed, please check file %s", serverAddr, chronyConfigFile)
 			}
 		}
@@ -789,7 +791,7 @@ func (n *NodeConfigureNtpServer) Execute(runtime connector.Runtime) error {
 		}
 
 		checkOrAddCmd := fmt.Sprintf(`grep -q '^server %s iburst' %s||sed '1a server %s iburst' -i %s`, serverAddr, chronyConfigFile, serverAddr, chronyConfigFile)
-		if _, err := runtime.GetRunner().Host.SudoCmd(checkOrAddCmd, false, false); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd(checkOrAddCmd, false, false); err != nil {
 			return errors.Wrapf(err, "set ntpserver: %s failed, please check file %s", serverAddr, chronyConfigFile)
 		}
 
@@ -798,11 +800,11 @@ func (n *NodeConfigureNtpServer) Execute(runtime connector.Runtime) error {
 	// if Timezone was configured
 	if len(n.KubeConf.Cluster.System.Timezone) > 0 {
 		setTimeZoneCmd := fmt.Sprintf("timedatectl set-timezone %s", n.KubeConf.Cluster.System.Timezone)
-		if _, err := runtime.GetRunner().Host.SudoCmd(setTimeZoneCmd, false, false); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd(setTimeZoneCmd, false, false); err != nil {
 			return errors.Wrapf(err, "set timezone: %s failed", n.KubeConf.Cluster.System.Timezone)
 		}
 
-		if _, err := runtime.GetRunner().Host.SudoCmd("timedatectl set-ntp true", false, false); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd("timedatectl set-ntp true", false, false); err != nil {
 			return errors.Wrap(err, "timedatectl set-ntp true failed")
 		}
 	}
@@ -810,12 +812,12 @@ func (n *NodeConfigureNtpServer) Execute(runtime connector.Runtime) error {
 	// ensure chronyd was enabled and work normally
 	if len(n.KubeConf.Cluster.System.NtpServers) > 0 || len(n.KubeConf.Cluster.System.Timezone) > 0 {
 		startChronyCmd := fmt.Sprintf("systemctl enable %s && systemctl restart %s", chronyService, chronyService)
-		if _, err := runtime.GetRunner().Host.SudoCmd(startChronyCmd, false, false); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd(startChronyCmd, false, false); err != nil {
 			return errors.Wrap(err, "restart chronyd failed")
 		}
 
 		// tells chronyd to cancel any remaining correction that was being slewed and jump the system clock by the equivalent amount, making it correct immediately.
-		if _, err := runtime.GetRunner().Host.SudoCmd("chronyc makestep > /dev/null && chronyc sources", false, true); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd("chronyc makestep > /dev/null && chronyc sources", false, true); err != nil {
 			return errors.Wrap(err, "chronyc makestep failed")
 		}
 	}

--- a/pkg/bootstrap/patch/tasks.go
+++ b/pkg/bootstrap/patch/tasks.go
@@ -21,9 +21,9 @@ type EnableSSHTask struct {
 }
 
 func (t *EnableSSHTask) Execute(runtime connector.Runtime) error {
-	stdout, _ := runtime.GetRunner().Host.SudoCmd("systemctl is-active ssh", false, false)
+	stdout, _ := runtime.GetRunner().SudoCmd("systemctl is-active ssh", false, false)
 	if stdout != "active" {
-		if _, err := runtime.GetRunner().Host.SudoCmd("systemctl enable --now ssh", false, false); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd("systemctl enable --now ssh", false, false); err != nil {
 			return err
 		}
 	}
@@ -62,14 +62,14 @@ func (t *PatchTask) Execute(runtime connector.Runtime) error {
 	switch platformFamily {
 	case common.Debian:
 		if _, err := util.GetCommand("add-apt-repository"); err != nil {
-			if _, err := runtime.GetRunner().Host.SudoCmd("apt install -y software-properties-common", false, true); err != nil {
+			if _, err := runtime.GetRunner().SudoCmd("apt install -y software-properties-common", false, true); err != nil {
 				logger.Errorf("install add-apt-repository error %v", err)
 				return err
 			}
 		}
 
 		var cmd = fmt.Sprintf("add-apt-repository 'deb http://deb.debian.org/debian %s contrib non-free' -y", systemInfo.GetDebianVersionCode())
-		if _, err := runtime.GetRunner().Host.SudoCmd(cmd, false, true); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd(cmd, false, true); err != nil {
 			logger.Errorf("add os repo error %v", err)
 			return err
 		}
@@ -78,47 +78,47 @@ func (t *PatchTask) Execute(runtime connector.Runtime) error {
 	case common.Ubuntu:
 		if systemInfo.IsUbuntu() {
 			if !systemInfo.IsPveOrPveLxc() && !systemInfo.IsRaspbian() {
-				if _, err := runtime.GetRunner().Host.SudoCmd("add-apt-repository universe -y", false, true); err != nil {
+				if _, err := runtime.GetRunner().SudoCmd("add-apt-repository universe -y", false, true); err != nil {
 					logger.Errorf("add os repo error %v", err)
 					return err
 				}
 
-				if _, err := runtime.GetRunner().Host.SudoCmd("add-apt-repository multiverse -y", false, true); err != nil {
+				if _, err := runtime.GetRunner().SudoCmd("add-apt-repository multiverse -y", false, true); err != nil {
 					logger.Errorf("add os repo error %v", err)
 					return err
 				}
 			}
 		}
 
-		if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("%s update -qq", pkgManager), false, true); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("%s update -qq", pkgManager), false, true); err != nil {
 			logger.Errorf("update os error %v", err)
 			return err
 		}
 
 		logger.Debug("apt update success")
 
-		if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("%s install -y -qq %s", pkgManager, pre_reqs), false, true); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("%s install -y -qq %s", pkgManager, pre_reqs), false, true); err != nil {
 			logger.Errorf("install deps %s error %v", pre_reqs, err)
 			return err
 		}
 
 		var cmd = "conntrack socat apache2-utils ntpdate net-tools make gcc bison flex tree unzip"
-		if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("%s %s install -y %s", debianFrontend, pkgManager, cmd), false, true); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("%s %s install -y %s", debianFrontend, pkgManager, cmd), false, true); err != nil {
 			logger.Errorf("install deps %s error %v", cmd, err)
 			return err
 		}
 
-		if _, err := runtime.GetRunner().Host.SudoCmd("update-pciids", false, true); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd("update-pciids", false, true); err != nil {
 			return fmt.Errorf("failed to update-pciids: %v", err)
 		}
 
-		if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("%s %s install -y openssh-server", debianFrontend, pkgManager), false, true); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("%s %s install -y openssh-server", debianFrontend, pkgManager), false, true); err != nil {
 			logger.Errorf("install deps %s error %v", cmd, err)
 			return err
 		}
 	case common.CentOs, common.Fedora, common.RHEl:
 		cmd = "conntrack socat httpd-tools ntpdate net-tools make gcc openssh-server"
-		if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("%s install -y %s", pkgManager, cmd), false, true); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("%s install -y %s", pkgManager, cmd), false, true); err != nil {
 			logger.Errorf("install deps %s error %v", cmd, err)
 			return err
 		}
@@ -139,14 +139,14 @@ func (t *SocatTask) Execute(runtime connector.Runtime) error {
 		return err
 	}
 	f := path.Join(filePath, fileName)
-	if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("tar xzvf %s -C %s", f, filePath), false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("tar xzvf %s -C %s", f, filePath), false, false); err != nil {
 		logger.Errorf("failed to extract %s %v", f, err)
 		return err
 	}
 
 	tp := path.Join(filePath, fmt.Sprintf("socat-%s", kubekeyapiv1alpha2.DefaultSocatVersion))
 	if err := util.ChangeDir(tp); err == nil {
-		if _, err := runtime.GetRunner().Host.SudoCmd("./configure --prefix=/usr && make -j4 && make install && strip socat", false, false); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd("./configure --prefix=/usr && make -j4 && make install && strip socat", false, false); err != nil {
 			logger.Errorf("failed to install socat %v", err)
 			return err
 		}
@@ -178,12 +178,12 @@ func (t *ConntrackTask) Execute(runtime connector.Runtime) error {
 	fl := path.Join(flexFilePath, flexFileName)
 	f := path.Join(filePath, fileName)
 
-	if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("tar xzvf %s -C %s", fl, filePath), false, true); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("tar xzvf %s -C %s", fl, filePath), false, true); err != nil {
 		logger.Errorf("failed to extract %s %v", flexFilePath, err)
 		return err
 	}
 
-	if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("tar xzvf %s -C %s", f, filePath), false, true); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("tar xzvf %s -C %s", f, filePath), false, true); err != nil {
 		logger.Errorf("failed to extract %s %v", f, err)
 		return err
 	}
@@ -191,7 +191,7 @@ func (t *ConntrackTask) Execute(runtime connector.Runtime) error {
 	// install
 	fp := path.Join(flexFilePath, fmt.Sprintf("flex-%s", kubekeyapiv1alpha2.DefaultFlexVersion))
 	if err := util.ChangeDir(fp); err == nil {
-		if _, err := runtime.GetRunner().Host.SudoCmd("autoreconf -i && ./configure --prefix=/usr && make -j4 && make install", false, true); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd("autoreconf -i && ./configure --prefix=/usr && make -j4 && make install", false, true); err != nil {
 			logger.Errorf("failed to install flex %v", err)
 			return err
 		}
@@ -199,7 +199,7 @@ func (t *ConntrackTask) Execute(runtime connector.Runtime) error {
 
 	tp := path.Join(filePath, fmt.Sprintf("conntrack-tools-conntrack-tools-%s", kubekeyapiv1alpha2.DefaultConntrackVersion))
 	if err := util.ChangeDir(tp); err == nil {
-		if _, err := runtime.GetRunner().Host.SudoCmd("autoreconf -i && ./configure --prefix=/usr && make -j4 && make install", false, true); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd("autoreconf -i && ./configure --prefix=/usr && make -j4 && make install", false, true); err != nil {
 			logger.Errorf("failed to install conntrack %v", err)
 			return err
 		}
@@ -222,7 +222,7 @@ func (t *CorrectHostname) Execute(runtime connector.Runtime) error {
 		return nil
 	}
 	hostname := strings.ToLower(hostName)
-	if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("hostnamectl set-hostname %s", hostname), false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("hostnamectl set-hostname %s", hostname), false, false); err != nil {
 		return err
 	}
 	runtime.GetSystemInfo().SetHostname(hostname)
@@ -238,19 +238,19 @@ func (t *RaspbianCheckTask) Execute(runtime connector.Runtime) error {
 	systemInfo := runtime.GetSystemInfo()
 	if systemInfo.IsRaspbian() {
 		if _, err := util.GetCommand(common.CommandIptables); err != nil {
-			_, err = runtime.GetRunner().Host.SudoCmd("apt install -y iptables", false, false)
+			_, err = runtime.GetRunner().SudoCmd("apt install -y iptables", false, false)
 			if err != nil {
 				logger.Errorf("%s install iptables error %v", common.Raspbian, err)
 				return err
 			}
 
-			_, err = runtime.GetRunner().Host.Cmd("systemctl disable --user gvfs-udisks2-volume-monitor", false, true)
+			_, err = runtime.GetRunner().Cmd("systemctl disable --user gvfs-udisks2-volume-monitor", false, true)
 			if err != nil {
 				logger.Errorf("%s exec error %v", common.Raspbian, err)
 				return err
 			}
 
-			_, err = runtime.GetRunner().Host.Cmd("systemctl stop --user gvfs-udisks2-volume-monitor", false, true)
+			_, err = runtime.GetRunner().Cmd("systemctl stop --user gvfs-udisks2-volume-monitor", false, true)
 			if err != nil {
 				logger.Errorf("%s exec error %v", common.Raspbian, err)
 				return err
@@ -271,13 +271,13 @@ type DisableLocalDNSTask struct {
 func (t *DisableLocalDNSTask) Execute(runtime connector.Runtime) error {
 	switch runtime.GetSystemInfo().GetOsPlatformFamily() {
 	case common.Ubuntu, common.Debian:
-		stdout, _ := runtime.GetRunner().Host.SudoCmd("systemctl is-active systemd-resolved", false, false)
+		stdout, _ := runtime.GetRunner().SudoCmd("systemctl is-active systemd-resolved", false, false)
 		if stdout == "active" {
-			_, _ = runtime.GetRunner().Host.SudoCmd("systemctl stop systemd-resolved.service", false, true)
-			_, _ = runtime.GetRunner().Host.SudoCmd("systemctl disable systemd-resolved.service", false, true)
+			_, _ = runtime.GetRunner().SudoCmd("systemctl stop systemd-resolved.service", false, true)
+			_, _ = runtime.GetRunner().SudoCmd("systemctl disable systemd-resolved.service", false, true)
 
 			if utils.IsExist("/usr/bin/systemd-resolve") {
-				_, _ = runtime.GetRunner().Host.SudoCmd("mv /usr/bin/systemd-resolve /usr/bin/systemd-resolve.bak", false, true)
+				_, _ = runtime.GetRunner().SudoCmd("mv /usr/bin/systemd-resolve /usr/bin/systemd-resolve.bak", false, true)
 			}
 			ok, err := utils.IsSymLink("/etc/resolv.conf")
 			if err != nil {
@@ -285,7 +285,7 @@ func (t *DisableLocalDNSTask) Execute(runtime connector.Runtime) error {
 				return err
 			}
 			if ok {
-				if _, err := runtime.GetRunner().Host.SudoCmd("unlink /etc/resolv.conf && touch /etc/resolv.conf", false, true); err != nil {
+				if _, err := runtime.GetRunner().SudoCmd("unlink /etc/resolv.conf && touch /etc/resolv.conf", false, true); err != nil {
 					logger.Errorf("unlink /etc/resolv.conf error %v", err)
 					return err
 				}
@@ -296,7 +296,7 @@ func (t *DisableLocalDNSTask) Execute(runtime connector.Runtime) error {
 				return err
 			}
 		} else {
-			if _, err := runtime.GetRunner().Host.SudoCmd("cat /etc/resolv.conf > /etc/resolv.conf.bak", false, true); err != nil {
+			if _, err := runtime.GetRunner().SudoCmd("cat /etc/resolv.conf > /etc/resolv.conf.bak", false, true); err != nil {
 				logger.Errorf("backup /etc/resolv.conf error %v", err)
 				return err
 			}
@@ -315,14 +315,14 @@ func (t *DisableLocalDNSTask) Execute(runtime connector.Runtime) error {
 	sysInfo := runtime.GetSystemInfo()
 	localIp := sysInfo.GetLocalIp()
 	hostname := sysInfo.GetHostname()
-	if stdout, _ := runtime.GetRunner().Host.SudoCmd("hostname -i &>/dev/null", false, true); stdout == "" {
-		if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("echo %s %s >> /etc/hosts", localIp, hostname), false, true); err != nil {
+	if stdout, _ := runtime.GetRunner().SudoCmd("hostname -i &>/dev/null", false, true); stdout == "" {
+		if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("echo %s %s >> /etc/hosts", localIp, hostname), false, true); err != nil {
 			return errors.Wrap(err, "failed to set hostname mapping")
 		}
 	}
 
 	if runtime.GetSystemInfo().IsWsl() {
-		_, _ = runtime.GetRunner().Host.SudoCmd("chattr +i /etc/hosts /etc/resolv.conf", false, false)
+		_, _ = runtime.GetRunner().SudoCmd("chattr +i /etc/hosts /etc/resolv.conf", false, false)
 	}
 
 	return nil
@@ -338,7 +338,7 @@ func ConfigResolvConf(runtime connector.Runtime) error {
 	if common.CloudVendor == common.CloudVendorAliYun {
 		secondNameserverOp = appendOp
 		cmd = `echo 'nameserver 100.100.2.136' > /etc/resolv.conf`
-		if _, err = runtime.GetRunner().Host.SudoCmd(cmd, false, true); err != nil {
+		if _, err = runtime.GetRunner().SudoCmd(cmd, false, true); err != nil {
 			logger.Errorf("exec %s error %v", cmd, err)
 			return err
 		}
@@ -347,13 +347,13 @@ func ConfigResolvConf(runtime connector.Runtime) error {
 	}
 
 	cmd = fmt.Sprintf("echo 'nameserver 1.1.1.1' %s /etc/resolv.conf", secondNameserverOp)
-	if _, err = runtime.GetRunner().Host.SudoCmd(cmd, false, true); err != nil {
+	if _, err = runtime.GetRunner().SudoCmd(cmd, false, true); err != nil {
 		logger.Errorf("exec %s error %v", cmd, err)
 		return err
 	}
 
 	cmd = `echo 'nameserver 114.114.114.114' >> /etc/resolv.conf`
-	if _, err = runtime.GetRunner().Host.SudoCmd(cmd, false, true); err != nil {
+	if _, err = runtime.GetRunner().SudoCmd(cmd, false, true); err != nil {
 		logger.Errorf("exec %s error %v", cmd, err)
 		return err
 	}

--- a/pkg/bootstrap/registry/certs.go
+++ b/pkg/bootstrap/registry/certs.go
@@ -77,7 +77,7 @@ func (f *FetchCerts) Execute(runtime connector.Runtime) error {
 	src := "/etc/ssl/registry/ssl"
 	dst := fmt.Sprintf("%s/pki/registry", runtime.GetWorkDir())
 
-	certs, err := runtime.GetRunner().Host.SudoCmd("ls /etc/ssl/registry/ssl/ | grep .pem", false, false)
+	certs, err := runtime.GetRunner().SudoCmd("ls /etc/ssl/registry/ssl/ | grep .pem", false, false)
 	if err != nil {
 		return nil
 	}
@@ -85,7 +85,7 @@ func (f *FetchCerts) Execute(runtime connector.Runtime) error {
 	certsList := strings.Split(certs, "\r\n")
 	if len(certsList) > 0 {
 		for _, cert := range certsList {
-			if err := runtime.GetRunner().Host.Fetch(filepath.Join(dst, cert), filepath.Join(src, cert), false, true); err != nil {
+			if err := runtime.GetRunner().Fetch(filepath.Join(dst, cert), filepath.Join(src, cert), false, true); err != nil {
 				return errors.Wrap(err, fmt.Sprintf("Fetch %s failed", filepath.Join(src, cert)))
 			}
 		}

--- a/pkg/bootstrap/registry/tasks.go
+++ b/pkg/bootstrap/registry/tasks.go
@@ -45,7 +45,7 @@ func (s *SyncCertsFile) Execute(runtime connector.Runtime) error {
 	fileList := files.([]string)
 
 	for _, fileName := range fileList {
-		if err := runtime.GetRunner().Host.SudoScp(filepath.Join(dir, fileName), filepath.Join(common.RegistryCertDir, fileName)); err != nil {
+		if err := runtime.GetRunner().SudoScp(filepath.Join(dir, fileName), filepath.Join(common.RegistryCertDir, fileName)); err != nil {
 			return errors.Wrap(errors.WithStack(err), "scp registry certs file failed")
 		}
 	}
@@ -84,11 +84,11 @@ func (s *SyncCertsToAllNodes) Execute(runtime connector.Runtime) error {
 			}
 		}
 
-		if err := runtime.GetRunner().Host.SudoScp(filepath.Join(dir, fileName), filepath.Join(filepath.Join("/etc/docker/certs.d", RegistryCertificateBaseName), dstFileName)); err != nil {
+		if err := runtime.GetRunner().SudoScp(filepath.Join(dir, fileName), filepath.Join(filepath.Join("/etc/docker/certs.d", RegistryCertificateBaseName), dstFileName)); err != nil {
 			return errors.Wrap(errors.WithStack(err), "scp registry certs file to /etc/docker/certs.d/ failed")
 		}
 
-		if err := runtime.GetRunner().Host.SudoScp(filepath.Join(dir, fileName), filepath.Join(common.RegistryCertDir, dstFileName)); err != nil {
+		if err := runtime.GetRunner().SudoScp(filepath.Join(dir, fileName), filepath.Join(common.RegistryCertDir, dstFileName)); err != nil {
 			return errors.Wrap(errors.WithStack(err), fmt.Sprintf("scp registry certs file to %s failed", common.RegistryCertDir))
 		}
 	}
@@ -117,12 +117,12 @@ func (g *InstallRegistryBinary) Execute(runtime connector.Runtime) error {
 	}
 
 	dst := filepath.Join(common.TmpDir, registry.FileName)
-	if err := runtime.GetRunner().Host.Scp(registry.Path(), dst); err != nil {
+	if err := runtime.GetRunner().Scp(registry.Path(), dst); err != nil {
 		return errors.Wrap(errors.WithStack(err), "sync etcd tar.gz failed")
 	}
 
 	installCmd := fmt.Sprintf("tar -zxf %s && mv -f registry /usr/local/bin/ && chmod +x /usr/local/bin/registry", dst)
-	if _, err := runtime.GetRunner().Host.SudoCmd(installCmd, false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(installCmd, false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "install etcd binaries failed")
 	}
 	return nil
@@ -134,7 +134,7 @@ type StartRegistryService struct {
 
 func (g *StartRegistryService) Execute(runtime connector.Runtime) error {
 	installCmd := "systemctl daemon-reload && systemctl enable registry && systemctl restart registry"
-	if _, err := runtime.GetRunner().Host.SudoCmd(installCmd, false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(installCmd, false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "start registry service failed")
 	}
 
@@ -166,12 +166,12 @@ func (g *InstallDockerCompose) Execute(runtime connector.Runtime) error {
 	}
 
 	dst := filepath.Join(common.TmpDir, compose.FileName)
-	if err := runtime.GetRunner().Host.Scp(compose.Path(), dst); err != nil {
+	if err := runtime.GetRunner().Scp(compose.Path(), dst); err != nil {
 		return errors.Wrap(errors.WithStack(err), "sync docker-compose failed")
 	}
 
 	installCmd := fmt.Sprintf("mv -f %s /usr/local/bin/docker-compose && chmod +x /usr/local/bin/docker-compose", dst)
-	if _, err := runtime.GetRunner().Host.SudoCmd(installCmd, false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(installCmd, false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "install dokcer-compose failed")
 	}
 
@@ -199,12 +199,12 @@ func (g *SyncHarborPackage) Execute(runtime connector.Runtime) error {
 	}
 
 	dst := filepath.Join(common.TmpDir, harbor.FileName)
-	if err := runtime.GetRunner().Host.Scp(harbor.Path(), dst); err != nil {
+	if err := runtime.GetRunner().Scp(harbor.Path(), dst); err != nil {
 		return errors.Wrap(errors.WithStack(err), "sync harbor package failed")
 	}
 
 	installCmd := fmt.Sprintf("tar -zxvf %s -C /opt", dst)
-	if _, err := runtime.GetRunner().Host.SudoCmd(installCmd, false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(installCmd, false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "unzip harbor package failed")
 	}
 
@@ -217,7 +217,7 @@ type StartHarbor struct {
 
 func (g *StartHarbor) Execute(runtime connector.Runtime) error {
 	startCmd := "cd /opt/harbor && chmod +x install.sh && export PATH=$PATH:/usr/local/bin; ./install.sh --with-notary --with-trivy --with-chartmuseum && systemctl daemon-reload && systemctl enable harbor && systemctl restart harbor"
-	if _, err := runtime.GetRunner().Host.SudoCmd(startCmd, false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(startCmd, false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "start harbor failed")
 	}
 

--- a/pkg/certs/prepares.go
+++ b/pkg/certs/prepares.go
@@ -30,7 +30,10 @@ type AutoRenewCertsEnabled struct {
 }
 
 func (a *AutoRenewCertsEnabled) PreCheck(runtime connector.Runtime) (bool, error) {
-	exist := runtime.GetRunner().Host.FileExist(filepath.Join("/etc/systemd/system/", templates.K8sCertsRenewService.Name()))
+	exist, err := runtime.GetRunner().FileExist(filepath.Join("/etc/systemd/system/", templates.K8sCertsRenewService.Name()))
+	if err != nil {
+		return false, err
+	}
 	if exist {
 		return !a.Not, nil
 	}

--- a/pkg/certs/tasks.go
+++ b/pkg/certs/tasks.go
@@ -84,7 +84,7 @@ func (l *ListClusterCerts) Execute(runtime connector.Runtime) error {
 
 	for _, certFileName := range certificateList {
 		certPath := filepath.Join(common.KubeCertDir, certFileName)
-		certContext, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("cat %s", certPath), false, false)
+		certContext, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("cat %s", certPath), false, false)
 		if err != nil {
 			return errors.Wrap(err, "get cluster certs failed")
 		}
@@ -97,7 +97,7 @@ func (l *ListClusterCerts) Execute(runtime connector.Runtime) error {
 	for _, kubeConfigFileName := range kubeConfigList {
 		kubeConfigPath := filepath.Join(common.KubeConfigDir, kubeConfigFileName)
 		newConfig := clientcmdapi.NewConfig()
-		kubeconfigBytes, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("cat %s", kubeConfigPath), false, false)
+		kubeconfigBytes, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("cat %s", kubeConfigPath), false, false)
 		decoded, _, err := clientcmdlatest.Codec.Decode([]byte(kubeconfigBytes), &schema.GroupVersionKind{Version: clientcmdlatest.Version, Kind: "Config"}, newConfig)
 		if err != nil {
 			return err
@@ -120,7 +120,7 @@ func (l *ListClusterCerts) Execute(runtime connector.Runtime) error {
 
 	for _, caCertFileName := range caCertificateList {
 		certPath := filepath.Join(common.KubeCertDir, caCertFileName)
-		caCertContext, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("cat %s", certPath), false, false)
+		caCertContext, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("cat %s", certPath), false, false)
 		if err != nil {
 			return errors.Wrap(err, "Failed to get cluster certs")
 		}
@@ -279,7 +279,7 @@ func (r *RenewCerts) Execute(runtime connector.Runtime) error {
 		"systemctl restart kubelet",
 	}
 
-	version, err := runtime.GetRunner().Host.SudoCmd("/usr/local/bin/kubeadm version -o short", true, false)
+	version, err := runtime.GetRunner().SudoCmd("/usr/local/bin/kubeadm version -o short", true, false)
 	if err != nil {
 		return errors.Wrap(errors.WithStack(err), "kubeadm get version failed")
 	}
@@ -288,18 +288,18 @@ func (r *RenewCerts) Execute(runtime connector.Runtime) error {
 		return errors.Wrap(errors.WithStack(err), "parse kubeadm version failed")
 	}
 	if cmp == -1 {
-		_, err := runtime.GetRunner().Host.SudoCmd(strings.Join(kubeadmAlphaList, " && "), false, false)
+		_, err := runtime.GetRunner().SudoCmd(strings.Join(kubeadmAlphaList, " && "), false, false)
 		if err != nil {
 			return errors.Wrap(err, "kubeadm alpha certs renew failed")
 		}
 	} else {
-		_, err := runtime.GetRunner().Host.SudoCmd(strings.Join(kubeadmList, " && "), false, false)
+		_, err := runtime.GetRunner().SudoCmd(strings.Join(kubeadmList, " && "), false, false)
 		if err != nil {
 			return errors.Wrap(err, "kubeadm alpha certs renew failed")
 		}
 	}
 
-	_, err = runtime.GetRunner().Host.SudoCmd(strings.Join(restartList, " && "), false, false)
+	_, err = runtime.GetRunner().SudoCmd(strings.Join(restartList, " && "), false, false)
 	if err != nil {
 		return errors.Wrap(err, "kube-apiserver, kube-schedule, kube-controller-manager or kubelet restart failed")
 	}
@@ -316,12 +316,12 @@ func (f *FetchKubeConfig) Execute(runtime connector.Runtime) error {
 	}
 
 	tmpConfigFile := filepath.Join(common.TmpDir, "admin.conf")
-	if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("cp /etc/kubernetes/admin.conf %s", tmpConfigFile), false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("cp /etc/kubernetes/admin.conf %s", tmpConfigFile), false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "copy kube config to /tmp/ failed")
 	}
 
 	host := runtime.RemoteHost()
-	if err := runtime.GetRunner().Host.Fetch(filepath.Join(runtime.GetWorkDir(), host.GetName(), "admin.conf"), tmpConfigFile, false, true); err != nil {
+	if err := runtime.GetRunner().Fetch(filepath.Join(runtime.GetWorkDir(), host.GetName(), "admin.conf"), tmpConfigFile, false, true); err != nil {
 		return errors.Wrap(errors.WithStack(err), "fetch kube config file failed")
 	}
 	return nil
@@ -333,17 +333,17 @@ type SyneKubeConfigToWorker struct {
 
 func (s *SyneKubeConfigToWorker) Execute(runtime connector.Runtime) error {
 	createConfigDirCmd := "mkdir -p /root/.kube"
-	if _, err := runtime.GetRunner().Host.SudoCmd(createConfigDirCmd, false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(createConfigDirCmd, false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "create .kube dir failed")
 	}
 
 	firstMaster := runtime.GetHostsByRole(common.Master)[0]
 	localFile := filepath.Join(runtime.GetWorkDir(), firstMaster.GetName(), "admin.conf")
-	if err := runtime.GetRunner().Host.SudoScp(localFile, "/root/.kube/config"); err != nil {
+	if err := runtime.GetRunner().SudoScp(localFile, "/root/.kube/config"); err != nil {
 		return errors.Wrap(errors.WithStack(err), "sudo scp config file to worker /root/.kube/config failed")
 	}
 
-	if _, err := runtime.GetRunner().Host.SudoCmd("chmod 0600 /root/.kube/config", false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd("chmod 0600 /root/.kube/config", false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "chmod 0600 /root/.kube/config failed")
 	}
 
@@ -354,41 +354,41 @@ func (s *SyneKubeConfigToWorker) Execute(runtime connector.Runtime) error {
 
 	if host := runtime.RemoteHost(); host.GetUser() != "root" {
 		userConfigDirCmd := "mkdir -p $HOME/.kube"
-		if _, err := runtime.GetRunner().Host.Cmd(userConfigDirCmd, false, false); err != nil {
+		if _, err := runtime.GetRunner().Cmd(userConfigDirCmd, false, false); err != nil {
 			return errors.Wrap(errors.WithStack(err), "user mkdir $HOME/.kube failed")
 		}
 
 		getKubeConfigCmdUsr := "cp -f /root/.kube/config $HOME/.kube/config"
-		if _, err := runtime.GetRunner().Host.SudoCmd(getKubeConfigCmdUsr, false, false); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd(getKubeConfigCmdUsr, false, false); err != nil {
 			return errors.Wrap(errors.WithStack(err), "user copy /etc/kubernetes/admin.conf to $HOME/.kube/config failed")
 		}
 
-		if _, err := runtime.GetRunner().Host.SudoCmd("chmod 0600 $HOME/.kube/config", false, false); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd("chmod 0600 $HOME/.kube/config", false, false); err != nil {
 			return errors.Wrap(errors.WithStack(err), "chmod 0600 $HOME/.kube/config failed")
 		}
 
-		// userId, err := runtime.GetRunner().Host.Cmd("echo $(id -u)", false, false)
+		// userId, err := runtime.GetRunner().Cmd("echo $(id -u)", false, false)
 		// if err != nil {
 		// 	return errors.Wrap(errors.WithStack(err), "get user id failed")
 		// }
 
-		// userGroupId, err := runtime.GetRunner().Host.Cmd("echo $(id -g)", false, false)
+		// userGroupId, err := runtime.GetRunner().Cmd("echo $(id -g)", false, false)
 		// if err != nil {
 		// 	return errors.Wrap(errors.WithStack(err), "get user group id failed")
 		// }
 
-		userId, err := runtime.GetRunner().Host.Cmd("echo $SUDO_UID", false, false)
+		userId, err := runtime.GetRunner().Cmd("echo $SUDO_UID", false, false)
 		if err != nil {
 			return errors.Wrap(errors.WithStack(err), "get user id failed")
 		}
 
-		userGroupId, err := runtime.GetRunner().Host.Cmd("echo $SUDO_GID", false, false)
+		userGroupId, err := runtime.GetRunner().Cmd("echo $SUDO_GID", false, false)
 		if err != nil {
 			return errors.Wrap(errors.WithStack(err), "get user group id failed")
 		}
 
 		chownKubeConfig := fmt.Sprintf("chown -R %s:%s $HOME/.kube", userId, userGroupId)
-		if _, err := runtime.GetRunner().Host.SudoCmd(chownKubeConfig, false, false); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd(chownKubeConfig, false, false); err != nil {
 			return errors.Wrap(errors.WithStack(err), "chown user kube config failed")
 		}
 	}
@@ -400,7 +400,7 @@ type EnableRenewService struct {
 }
 
 func (e *EnableRenewService) Execute(runtime connector.Runtime) error {
-	if _, err := runtime.GetRunner().Host.SudoCmd(
+	if _, err := runtime.GetRunner().SudoCmd(
 		"chmod +x /usr/local/bin/kube-scripts/k8s-certs-renew.sh && systemctl enable --now k8s-certs-renew.timer",
 		false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "enable k8s renew certs service failed")
@@ -413,8 +413,8 @@ type UninstallAutoRenewCerts struct {
 }
 
 func (u *UninstallAutoRenewCerts) Execute(runtime connector.Runtime) error {
-	_, _ = runtime.GetRunner().Host.SudoCmd("systemctl disable k8s-certs-renew.timer 1>/dev/null 2>/dev/null", false, false)
-	_, _ = runtime.GetRunner().Host.SudoCmd("systemctl stop k8s-certs-renew.timer 1>/dev/null 2>/dev/null", false, false)
+	_, _ = runtime.GetRunner().SudoCmd("systemctl disable k8s-certs-renew.timer 1>/dev/null 2>/dev/null", false, false)
+	_, _ = runtime.GetRunner().SudoCmd("systemctl stop k8s-certs-renew.timer 1>/dev/null 2>/dev/null", false, false)
 
 	files := []string{
 		filepath.Join("/usr/local/bin/kube-scripts/", templates.K8sCertsRenewScript.Name()),
@@ -422,7 +422,7 @@ func (u *UninstallAutoRenewCerts) Execute(runtime connector.Runtime) error {
 		filepath.Join("/etc/systemd/system/", templates.K8sCertsRenewTimer.Name()),
 	}
 	for _, file := range files {
-		_, _ = runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("rm -rf %s", file), false, false)
+		_, _ = runtime.GetRunner().SudoCmd(fmt.Sprintf("rm -rf %s", file), false, false)
 	}
 
 	return nil

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -111,6 +111,8 @@ const (
 	ClusterStatus = "clusterStatus"
 	ClusterExist  = "clusterExist"
 
+	MasterInfo = "masterInfo"
+
 	// CertsModule
 	Certificate   = "certificate"
 	CaCertificate = "caCertificate"
@@ -185,6 +187,7 @@ const (
 	ManifestImageList          = "images.mf"
 	TerminusStateFilePrepared  = ".prepared"
 	TerminusStateFileInstalled = ".installed"
+	MasterHostConfigFile       = "master.conf"
 )
 
 const (
@@ -231,6 +234,7 @@ const (
 	CacheMinioOperatorPath = "minio_operator_path"
 
 	CacheHostRedisPassword = "hostredis_password"
+	CacheHostRedisAddress  = "hostredis_address"
 	CachePreparedState     = "prepare_state"
 	CacheInstalledState    = "install_state"
 

--- a/pkg/common/kube_module.go
+++ b/pkg/common/kube_module.go
@@ -28,7 +28,7 @@ type KubeConf struct {
 	Cluster      *kubekeyapiv1alpha2.ClusterSpec
 	Kubeconfig   string
 	ClientSet    *kubekeyclientset.Clientset
-	Arg          Argument
+	Arg          *Argument
 }
 
 type KubeModule struct {

--- a/pkg/common/kube_runtime.go
+++ b/pkg/common/kube_runtime.go
@@ -19,6 +19,8 @@ package common
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/pkg/errors"
+	"github.com/spf13/pflag"
 	"net"
 	"os"
 	"path/filepath"
@@ -40,7 +42,7 @@ type KubeRuntime struct {
 	Cluster     *kubekeyapiv1alpha2.ClusterSpec
 	Kubeconfig  string
 	ClientSet   *kubekeyclientset.Clientset
-	Arg         Argument
+	Arg         *Argument
 }
 
 type Argument struct {
@@ -79,13 +81,9 @@ type Argument struct {
 	DownloadCdnUrl  string `json:"download_cdn_url"`
 
 	// master node ssh config
-	MasterHost              string `json:"master_host"`
-	MasterNodeName          string `json:"master_node_name"`
-	MasterSSHPort           int    `json:"master_ssh_port"`
-	MasterSSHUser           string `json:"master_ssh_user"`
-	MasterSSHPassword       string `json:"-"`
-	MasterSSHPrivateKeyPath string `json:"-"`
-	LocalSSHPort            int    `json:"-"`
+	*MasterHostConfig
+
+	LocalSSHPort int `json:"-"`
 
 	SkipMasterPullImages bool `json:"skip_master_pull_images"`
 
@@ -122,6 +120,34 @@ type Argument struct {
 	HostIP             string   `json:"host_ip"`
 
 	CudaVersion string `json:"cuda_version"`
+}
+
+type MasterHostConfig struct {
+	MasterHost              string `json:"master_host"`
+	MasterNodeName          string `json:"master_node_name"`
+	MasterSSHUser           string `json:"master_ssh_user"`
+	MasterSSHPassword       string `json:"master_ssh_password"`
+	MasterSSHPrivateKeyPath string `json:"master_ssh_private_key_path"`
+	MasterSSHPort           int    `json:"master_ssh_port"`
+}
+
+func (cfg *MasterHostConfig) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&cfg.MasterHost, "master-host", "", "IP address of the master node")
+	fs.StringVar(&cfg.MasterNodeName, "master-node-name", "", "Name of the master node")
+	fs.StringVar(&cfg.MasterSSHUser, "master-ssh-user", "", "Username of the master node, defaults to root")
+	fs.StringVar(&cfg.MasterSSHPassword, "master-ssh-password", "", "Password of the master node")
+	fs.StringVar(&cfg.MasterSSHPrivateKeyPath, "master-ssh-private-key-path", "", "Path to the SSH key to access the master node, defaults to ~/.ssh/id_rsa")
+	fs.IntVar(&cfg.MasterSSHPort, "master-ssh-port", 0, "SSH Port of the master node, defaults to 22")
+}
+
+func (cfg *MasterHostConfig) Validate() error {
+	if cfg.MasterHost == "" {
+		return errors.New("--master-host is not provided")
+	}
+	if cfg.MasterSSHUser != "" && cfg.MasterSSHUser != "root" && cfg.MasterSSHPassword == "" {
+		return errors.New("--master-ssh-password must be provided for non-root user in order to execute sudo command")
+	}
+	return nil
 }
 
 type PublicNetworkInfo struct {
@@ -211,6 +237,7 @@ func NewArgument() *Argument {
 		TerminusDNSServiceAPI:  os.Getenv(ENV_TERMINUS_DNS_SERVICE_API),
 		HostIP:                 os.Getenv(ENV_HOST_IP),
 		Environment:            os.Environ(),
+		MasterHostConfig:       &MasterHostConfig{},
 	}
 	arg.IsCloudInstance, _ = strconv.ParseBool(os.Getenv(ENV_TERMINUS_IS_CLOUD_VERSION))
 	arg.PublicNetworkInfo.PubliclyAccessible, _ = strconv.ParseBool(os.Getenv(ENV_PUBLICLY_ACCESSIBLE))
@@ -354,6 +381,9 @@ func (a *Argument) SetKubernetesVersion(kubeType string, kubeVersion string) {
 }
 
 func (a *Argument) SetBaseDir(dir string) {
+	if dir == "" {
+		dir = a.SystemInfo.GetHomeDir()
+	}
 	a.BaseDir = dir
 	if dir != "" && !filepath.IsAbs(dir) {
 		dir, _ = filepath.Abs(dir)
@@ -377,6 +407,47 @@ func (a *Argument) SetManifest(manifest string) {
 func (a *Argument) SetConsoleLog(fileName string, truncate bool) {
 	a.ConsoleLogFileName = fileName
 	a.ConsoleLogTruncate = truncate
+}
+
+func (a *Argument) SetMasterHostOverride(config MasterHostConfig) {
+	if config.MasterHost != "" {
+		a.MasterHost = config.MasterHost
+	}
+	if config.MasterNodeName != "" {
+		a.MasterNodeName = config.MasterNodeName
+	}
+
+	// set a dummy name to bypass validity checks
+	// as it will be overridden later when the node name is fetched
+	if a.MasterNodeName == "" {
+		a.MasterNodeName = "master"
+	}
+	if config.MasterSSHPassword != "" {
+		a.MasterSSHPassword = config.MasterSSHPassword
+	}
+	if config.MasterSSHUser != "" {
+		a.MasterSSHUser = config.MasterSSHUser
+	}
+	if config.MasterSSHPort != 0 {
+		a.MasterSSHPort = config.MasterSSHPort
+	}
+	if config.MasterSSHPrivateKeyPath != "" {
+		a.MasterSSHPrivateKeyPath = config.MasterSSHPrivateKeyPath
+	}
+}
+
+func (a *Argument) LoadMasterHostConfigIfAny() error {
+	if a.BaseDir == "" {
+		return errors.New("basedir unset")
+	}
+	content, err := os.ReadFile(filepath.Join(a.BaseDir, MasterHostConfigFile))
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(content, a.MasterHostConfig)
 }
 
 func NewKubeRuntime(flag string, arg Argument) (*KubeRuntime, error) {
@@ -422,7 +493,7 @@ func NewKubeRuntime(flag string, arg Argument) (*KubeRuntime, error) {
 	r := &KubeRuntime{
 		Cluster:     defaultCluster,
 		ClusterName: cluster.Name,
-		Arg:         arg,
+		Arg:         &arg,
 	}
 	r.BaseRuntime = base
 

--- a/pkg/common/prepares.go
+++ b/pkg/common/prepares.go
@@ -34,7 +34,7 @@ type GetCommandKubectl struct {
 
 func (p *GetCommandKubectl) PreCheck(runtime connector.Runtime) (bool, error) {
 
-	cmd, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("command -v %s", CommandKubectl), false, false)
+	cmd, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("command -v %s", CommandKubectl), false, false)
 	if err != nil {
 		return true, nil
 	}
@@ -55,7 +55,7 @@ func (p *GetMasterNum) PreCheck(runtime connector.Runtime) (bool, error) {
 	}
 
 	var cmd = fmt.Sprintf("%s get node | awk '{if(NR>1){print $3}}' | grep master | wc -l", kubectlpath)
-	stdout, err := runtime.GetRunner().Host.SudoCmd(cmd, false, false)
+	stdout, err := runtime.GetRunner().SudoCmd(cmd, false, false)
 	if err != nil {
 		return false, errors.Wrap(errors.WithStack(err), "get master num failed")
 	}
@@ -78,7 +78,7 @@ func (p *GetNodeNum) PreCheck(runtime connector.Runtime) (bool, error) {
 	}
 
 	var cmd = fmt.Sprintf("%s get node | wc -l", kubectlpath)
-	stdout, err := runtime.GetRunner().Host.SudoCmd(cmd, false, false)
+	stdout, err := runtime.GetRunner().SudoCmd(cmd, false, false)
 	if err != nil {
 		return false, errors.Wrap(errors.WithStack(err), "get node num failed")
 	}

--- a/pkg/container/containerd.go
+++ b/pkg/container/containerd.go
@@ -50,7 +50,7 @@ func (t *CreateZfsMount) Execute(runtime connector.Runtime) error {
 		return nil
 	}
 	var cmd = fmt.Sprintf("zfs create -o mountpoint=%s %s/containerd", cc.ZfsSnapshotter, systemInfo.GetDefaultZfsPrefixName())
-	if _, err := runtime.GetRunner().Host.SudoCmd(cmd, false, true); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(cmd, false, true); err != nil {
 		if strings.Contains(err.Error(), "already exists") {
 			logger.Debugf("zfs %s/containerd already exists", systemInfo.GetDefaultZfsPrefixName())
 			return nil
@@ -69,7 +69,7 @@ func (t *ZfsReset) Execute(runtime connector.Runtime) error {
 		return err
 	}
 	var systemInfo = runtime.GetSystemInfo()
-	res, _ := runtime.GetRunner().Host.SudoCmd("zfs list -t all", false, false)
+	res, _ := runtime.GetRunner().SudoCmd("zfs list -t all", false, false)
 	if res != "" {
 		scanner := bufio.NewScanner(strings.NewReader(res))
 		for scanner.Scan() {
@@ -89,13 +89,13 @@ func (t *ZfsReset) Execute(runtime connector.Runtime) error {
 				continue
 			}
 
-			if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("zfs destroy %s -frR", name), false, false); err == nil {
+			if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("zfs destroy %s -frR", name), false, false); err == nil {
 				fmt.Printf("delete zfs device %s\n", name)
 			}
 		}
 	}
 
-	runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("zfs destroy %s/containerd -frR", systemInfo.GetDefaultZfsPrefixName()), false, false)
+	runtime.GetRunner().SudoCmd(fmt.Sprintf("zfs destroy %s/containerd -frR", systemInfo.GetDefaultZfsPrefixName()), false, false)
 
 	return nil
 }
@@ -118,11 +118,11 @@ func (s *SyncContainerd) Execute(runtime connector.Runtime) error {
 	path := containerd.FilePath(s.BaseDir)
 
 	dst := filepath.Join(common.TmpDir, containerd.Filename)
-	if err := runtime.GetRunner().Host.Scp(path, dst); err != nil {
+	if err := runtime.GetRunner().Scp(path, dst); err != nil {
 		return errors.Wrap(errors.WithStack(err), fmt.Sprintf("sync containerd binaries failed"))
 	}
 
-	if _, err := runtime.GetRunner().Host.SudoCmd(
+	if _, err := runtime.GetRunner().SudoCmd(
 		fmt.Sprintf("mkdir -p /usr/bin && tar -zxf %s && mv bin/* /usr/bin && rm -rf bin", dst),
 		false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), fmt.Sprintf("install containerd binaries failed"))
@@ -149,11 +149,11 @@ func (s *SyncCrictlBinaries) Execute(runtime connector.Runtime) error {
 
 	dst := filepath.Join(common.TmpDir, crictl.Filename)
 
-	if err := runtime.GetRunner().Host.Scp(path, dst); err != nil {
+	if err := runtime.GetRunner().Scp(path, dst); err != nil {
 		return errors.Wrap(errors.WithStack(err), fmt.Sprintf("sync crictl binaries failed"))
 	}
 
-	if _, err := runtime.GetRunner().Host.SudoCmd(
+	if _, err := runtime.GetRunner().SudoCmd(
 		fmt.Sprintf("mkdir -p /usr/bin && tar -zxf %s -C /usr/bin ", dst),
 		false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), fmt.Sprintf("install crictl binaries failed"))
@@ -169,7 +169,7 @@ type EnableContainerd struct {
 func (e *EnableContainerd) Execute(runtime connector.Runtime) error {
 	var isK3s = strings.Contains(e.KubeConf.Arg.KubernetesVersion, "k3s")
 
-	if _, err := runtime.GetRunner().Host.SudoCmd(
+	if _, err := runtime.GetRunner().SudoCmd(
 		"systemctl daemon-reload && systemctl enable containerd && systemctl start containerd",
 		false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), fmt.Sprintf("enable and start containerd failed"))
@@ -194,11 +194,11 @@ func (e *EnableContainerd) Execute(runtime connector.Runtime) error {
 	path := containerd.FilePath(e.BaseDir)
 
 	dst := filepath.Join(common.TmpDir, containerd.Filename)
-	if err := runtime.GetRunner().Host.Scp(path, dst); err != nil {
+	if err := runtime.GetRunner().Scp(path, dst); err != nil {
 		return errors.Wrap(errors.WithStack(err), fmt.Sprintf("sync runc binaries failed"))
 	}
 
-	if _, err := runtime.GetRunner().Host.SudoCmd(
+	if _, err := runtime.GetRunner().SudoCmd(
 		fmt.Sprintf("install -m 755 %s /usr/local/sbin/runc", dst),
 		false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), fmt.Sprintf("install runc binaries failed"))
@@ -211,13 +211,13 @@ type DisableContainerd struct {
 }
 
 func (d *DisableContainerd) Execute(runtime connector.Runtime) error {
-	if stdout, err := runtime.GetRunner().Host.SudoCmd("systemctl status containerd", false, false); err != nil {
-		if strings.Contains(stdout, "could not be found") {
-			return nil
+	if stdout, err := runtime.GetRunner().SudoCmd("systemctl status containerd", false, false); err != nil {
+		if !strings.Contains(stdout, "could not be found") {
+			return err
 		}
-		return err
+	} else {
+		_, _ = runtime.GetRunner().SudoCmd("systemctl disable containerd && systemctl stop containerd", false, false)
 	}
-	_, _ = runtime.GetRunner().Host.SudoCmd("systemctl disable containerd && systemctl stop containerd", false, false)
 
 	if err := umountPoints(runtime); err != nil {
 		return err
@@ -246,7 +246,7 @@ func (d *DisableContainerd) Execute(runtime connector.Runtime) error {
 	}
 
 	for _, file := range files {
-		_, _ = runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("rm -rf %s", file), false, true)
+		_, _ = runtime.GetRunner().SudoCmd(fmt.Sprintf("rm -rf %s", file), false, true)
 	}
 	return nil
 }
@@ -271,7 +271,7 @@ func getProcessIds(pid string, runtime connector.Runtime) []string {
 func getChildPids(pid string, runtime connector.Runtime) []string {
 	var childs []string
 	var cmd = fmt.Sprintf("pgrep -P %s", pid)
-	chpids, err := runtime.GetRunner().Host.SudoCmd(cmd, false, false)
+	chpids, err := runtime.GetRunner().SudoCmd(cmd, false, false)
 	if err == nil && chpids != "" {
 		scanner := bufio.NewScanner(strings.NewReader(chpids))
 		for scanner.Scan() {
@@ -301,7 +301,7 @@ func umountPoints(runtime connector.Runtime) error {
 		if len(fields) >= 2 {
 			p := fields[1]
 			if util.IsExist(p) {
-				runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("umount %s", p), false, true)
+				runtime.GetRunner().SudoCmd(fmt.Sprintf("umount %s", p), false, true)
 			}
 		}
 	}
@@ -319,7 +319,7 @@ type CordonNode struct {
 
 func (d *CordonNode) Execute(runtime connector.Runtime) error {
 	nodeName := runtime.RemoteHost().GetName()
-	if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("/usr/local/bin/kubectl cordon %s ", nodeName), true, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("/usr/local/bin/kubectl cordon %s ", nodeName), true, false); err != nil {
 		return errors.Wrap(err, fmt.Sprintf("cordon the node: %s failed", nodeName))
 	}
 	return nil
@@ -333,7 +333,7 @@ func (d *UnCordonNode) Execute(runtime connector.Runtime) error {
 	nodeName := runtime.RemoteHost().GetName()
 	f := true
 	for f {
-		if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("/usr/local/bin/kubectl uncordon %s", nodeName), true, false); err == nil {
+		if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("/usr/local/bin/kubectl uncordon %s", nodeName), true, false); err == nil {
 			break
 		}
 
@@ -347,7 +347,7 @@ type DrainNode struct {
 
 func (d *DrainNode) Execute(runtime connector.Runtime) error {
 	nodeName := runtime.RemoteHost().GetName()
-	if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("/usr/local/bin/kubectl drain %s --delete-emptydir-data --ignore-daemonsets --timeout=2m --force", nodeName), true, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("/usr/local/bin/kubectl drain %s --delete-emptydir-data --ignore-daemonsets --timeout=2m --force", nodeName), true, false); err != nil {
 		return errors.Wrap(err, fmt.Sprintf("drain the node: %s failed", nodeName))
 	}
 	return nil
@@ -360,11 +360,11 @@ type RestartCri struct {
 func (i *RestartCri) Execute(runtime connector.Runtime) error {
 	switch i.KubeConf.Arg.Type {
 	case common.Docker:
-		if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("systemctl daemon-reload && systemctl restart docker "), true, false); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("systemctl daemon-reload && systemctl restart docker "), true, false); err != nil {
 			return errors.Wrap(err, "restart docker")
 		}
 	case common.Containerd:
-		if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("systemctl daemon-reload && systemctl restart containerd"), true, false); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("systemctl daemon-reload && systemctl restart containerd"), true, false); err != nil {
 			return errors.Wrap(err, "restart containerd")
 		}
 
@@ -381,13 +381,13 @@ type EditKubeletCri struct {
 func (i *EditKubeletCri) Execute(runtime connector.Runtime) error {
 	switch i.KubeConf.Arg.Type {
 	case common.Docker:
-		if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf(
+		if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf(
 			"sed -i 's#--container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock --pod#--pod#' /var/lib/kubelet/kubeadm-flags.env"),
 			true, false); err != nil {
 			return errors.Wrap(err, "Change KubeletTo Containerd failed")
 		}
 	case common.Containerd:
-		if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf(
+		if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf(
 			"sed -i 's#--network-plugin=cni --pod#--network-plugin=cni --container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock --pod#' /var/lib/kubelet/kubeadm-flags.env"),
 			true, false); err != nil {
 			return errors.Wrap(err, "Change KubeletTo Containerd failed")
@@ -405,7 +405,7 @@ type RestartKubeletNode struct {
 
 func (d *RestartKubeletNode) Execute(runtime connector.Runtime) error {
 
-	if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("systemctl restart kubelet"), true, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("systemctl restart kubelet"), true, false); err != nil {
 		return errors.Wrap(err, "RestartNode Kube failed")
 	}
 	return nil
@@ -680,8 +680,8 @@ type KillContainerdProcess struct {
 func (t *KillContainerdProcess) Execute(runtime connector.Runtime) error {
 	var pids []string
 	var childpids []string
-	var cmd = "ps -ef | grep containerd-shim | grep -v grep | awk '{print $2}'"
-	stdout, err := runtime.GetRunner().Host.SudoCmd(cmd, false, false)
+	var cmd = "ps -ef | grep containerd-shim | grep -v grep"
+	stdout, err := runtime.GetRunner().SudoCmd(cmd, false, false)
 	if err == nil || stdout != "" {
 		scanner := bufio.NewScanner(strings.NewReader(stdout))
 		for scanner.Scan() {
@@ -707,7 +707,7 @@ func (t *KillContainerdProcess) Execute(runtime connector.Runtime) error {
 
 	if len(allPids) > 0 {
 		for _, pid := range allPids {
-			runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("kill -9 %s", pid), false, false)
+			runtime.GetRunner().SudoCmd(fmt.Sprintf("kill -9 %s", pid), false, false)
 		}
 	}
 	return nil

--- a/pkg/container/docker.go
+++ b/pkg/container/docker.go
@@ -52,11 +52,11 @@ func (s *SyncDockerBinaries) Execute(runtime connector.Runtime) error {
 	}
 
 	dst := filepath.Join(common.TmpDir, docker.FileName)
-	if err := runtime.GetRunner().Host.Scp(docker.Path(), dst); err != nil {
+	if err := runtime.GetRunner().Scp(docker.Path(), dst); err != nil {
 		return errors.Wrap(errors.WithStack(err), fmt.Sprintf("sync docker binaries failed"))
 	}
 
-	if _, err := runtime.GetRunner().Host.SudoCmd(
+	if _, err := runtime.GetRunner().SudoCmd(
 		fmt.Sprintf("mkdir -p /usr/bin && tar -zxf %s && mv docker/* /usr/bin && rm -rf docker", dst),
 		false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), fmt.Sprintf("install container runtime docker binaries failed"))
@@ -69,7 +69,7 @@ type EnableDocker struct {
 }
 
 func (e *EnableDocker) Execute(runtime connector.Runtime) error {
-	if _, err := runtime.GetRunner().Host.SudoCmd(
+	if _, err := runtime.GetRunner().SudoCmd(
 		"systemctl daemon-reload && systemctl enable docker && systemctl start docker",
 		false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), fmt.Sprintf("enable and start docker failed"))
@@ -90,18 +90,18 @@ func (p *DockerLoginRegistry) Execute(runtime connector.Runtime) error {
 			continue
 		}
 		cmd := fmt.Sprintf("docker login --username \"%s\" --password \"%s\" %s", entry.Username, entry.Password, repo)
-		if _, err := runtime.GetRunner().Host.SudoCmd(cmd, false, false); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd(cmd, false, false); err != nil {
 			return errors.Wrapf(err, "login registry failed, cmd: %v, err:%v", cmd, err)
 		}
 	}
 
-	if output, err := runtime.GetRunner().Host.SudoCmd(
+	if output, err := runtime.GetRunner().SudoCmd(
 		"if [ -e $HOME/.docker/config.json ]; "+
 			"then echo 'exist'; "+
 			"fi", false, false); err == nil && strings.Contains(output, "exist") {
 
 		cmd := "mkdir -p /.docker && cp -f $HOME/.docker/config.json /.docker/ && chmod 0644 /.docker/config.json "
-		if _, err := runtime.GetRunner().Host.SudoCmd(cmd, false, false); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd(cmd, false, false); err != nil {
 			return errors.Wrapf(err, "copy docker auths failed cmd: %v, err:%v", cmd, err)
 		}
 	}
@@ -114,7 +114,7 @@ type DisableDocker struct {
 }
 
 func (d *DisableDocker) Execute(runtime connector.Runtime) error {
-	if _, err := runtime.GetRunner().Host.SudoCmd("systemctl disable docker && systemctl stop docker",
+	if _, err := runtime.GetRunner().SudoCmd("systemctl disable docker && systemctl stop docker",
 		false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), fmt.Sprintf("disable and stop docker failed"))
 	}
@@ -135,7 +135,7 @@ func (d *DisableDocker) Execute(runtime connector.Runtime) error {
 	}
 
 	for _, file := range files {
-		_, _ = runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("rm -rf %s", file), false, true)
+		_, _ = runtime.GetRunner().SudoCmd(fmt.Sprintf("rm -rf %s", file), false, true)
 	}
 	return nil
 }

--- a/pkg/container/prepares.go
+++ b/pkg/container/prepares.go
@@ -29,7 +29,7 @@ type DockerExist struct {
 }
 
 func (d *DockerExist) PreCheck(runtime connector.Runtime) (bool, error) {
-	output, err := runtime.GetRunner().Host.SudoCmd("if [ -z $(which docker) ] || [ ! -e /var/run/docker.sock ]; "+
+	output, err := runtime.GetRunner().SudoCmd("if [ -z $(which docker) ] || [ ! -e /var/run/docker.sock ]; "+
 		"then echo 'not exist'; "+
 		"fi", false, false)
 	if err != nil {
@@ -47,7 +47,7 @@ type CrictlExist struct {
 }
 
 func (c *CrictlExist) PreCheck(runtime connector.Runtime) (bool, error) {
-	output, err := runtime.GetRunner().Host.SudoCmd(
+	output, err := runtime.GetRunner().SudoCmd(
 		"if [ -z $(which crictl) ]; "+
 			"then echo 'not exist'; "+
 			"fi", false, false)
@@ -67,7 +67,7 @@ type ContainerdExist struct {
 }
 
 func (c *ContainerdExist) PreCheck(runtime connector.Runtime) (bool, error) {
-	output, err := runtime.GetRunner().Host.SudoCmd(
+	output, err := runtime.GetRunner().SudoCmd(
 		"if [ -z $(which containerd) ] || [ ! -e /run/containerd/containerd.sock ]; "+
 			"then echo 'not exist'; "+
 			"fi", false, false)

--- a/pkg/core/action/script.go
+++ b/pkg/core/action/script.go
@@ -45,7 +45,7 @@ func (s *Script) Execute(runtime connector.Runtime) error {
 	}
 
 	var cmd = fmt.Sprintf("%s bash %s %s", envs, s.File, strings.Join(s.Args, " "))
-	_, err := runtime.GetRunner().Host.SudoCmd(cmd, s.PrintOutput, s.PrintLine)
+	_, err := runtime.GetRunner().SudoCmd(cmd, s.PrintOutput, s.PrintLine)
 	if err != nil {
 		return errors.Wrap(errors.WithStack(err), fmt.Sprintf("exec script %s failed, args: %v", s.File, s.Args))
 	}

--- a/pkg/core/action/template.go
+++ b/pkg/core/action/template.go
@@ -61,7 +61,7 @@ func (t *Template) Execute(runtime connector.Runtime) error {
 		return errors.Wrap(errors.WithStack(err), fmt.Sprintf("write file %s failed", fileName))
 	}
 
-	if err := runtime.GetRunner().Host.SudoScp(fileName, t.Dst); err != nil {
+	if err := runtime.GetRunner().SudoScp(fileName, t.Dst); err != nil {
 		return errors.Wrap(errors.WithStack(err), fmt.Sprintf("scp file %s to remote %s failed", fileName, t.Dst))
 	}
 

--- a/pkg/core/connector/interface.go
+++ b/pkg/core/connector/interface.go
@@ -56,6 +56,7 @@ type ModuleRuntime interface {
 	GetAllHosts() []Host
 	SetAllHosts([]Host)
 	GetHostsByRole(role string) []Host
+	GetLocalHost() Host
 	DeleteHost(host Host)
 	HostIsDeprecated(host Host) bool
 	// InitLogger() error
@@ -111,13 +112,16 @@ type Host interface {
 	Fetch(local, remote string, printOutput bool, printLine bool) error
 	SudoScp(local, remote string) error
 	Scp(local, remote string) error
-	FileExist(f string) bool
-	DirExist(d string) bool
+	FileExist(f string) (bool, error)
+	DirExist(d string) (bool, error)
 	MkDir(path string) error
 	Cmd(cmd string, printOutput bool, printLine bool) (string, error)
 	CmdExt(cmd string, printOutput bool, printLine bool) (string, error)
+	SudoPrefixIfNecessary(cmd string) string
 	SudoCmd(cmd string, printOutput bool, printLine bool) (string, error)
 	SudoCmdContext(ctx context.Context, cmd string, printOutput bool, printLine bool) (string, error)
 	CmdExtWithContext(ctx context.Context, cmd string, printOutput bool, printLine bool) (string, error)
 	MkDirAll(path string, mode string) error
+	Chmod(path string, mode os.FileMode) error
+	FileMd5(path string) (string, error)
 }

--- a/pkg/core/connector/runtime.go
+++ b/pkg/core/connector/runtime.go
@@ -207,6 +207,23 @@ func (b *BaseRuntime) GetHostsByRole(role string) []Host {
 	}
 }
 
+func (b *BaseRuntime) GetLocalHost() Host {
+	si := b.GetSystemInfo()
+	for i := range b.allHosts {
+		if b.allHosts[i].GetName() == si.GetHostname() {
+			return b.allHosts[i]
+		}
+	}
+	return &BaseHost{
+		Name:            common.LocalHost,
+		User:            si.GetUsername(),
+		Address:         si.GetLocalIp(),
+		InternalAddress: si.GetLocalIp(),
+		Arch:            si.GetOsArch(),
+		Os:              si.GetOsType(),
+	}
+}
+
 func (b *BaseRuntime) RemoteHost() Host {
 	return b.GetRunner().Host
 }

--- a/pkg/core/connector/ssh.go
+++ b/pkg/core/connector/ssh.go
@@ -394,7 +394,7 @@ func (c *connection) Fetch(local, remote string, host Host) error {
 	//defer srcFile.Close()
 
 	// Base64 encoding is performed on the contents of the file to prevent garbled code in the target file.
-	output, _, err := c.Exec(SudoPrefix(fmt.Sprintf("cat %s | base64 -w 0", remote)), host)
+	output, _, err := c.Exec(host.SudoPrefixIfNecessary(fmt.Sprintf("cat %s | base64 -w 0", remote)), host)
 	if err != nil {
 		return fmt.Errorf("open remote file failed %v, remote path: %s", err, remote)
 	}
@@ -549,7 +549,7 @@ func (c *connection) RemoteFileExist(dst string, host Host) bool {
 	remoteFileName := path.Base(dst)
 	remoteFileDirName := path.Dir(dst)
 
-	remoteFileCommand := fmt.Sprintf(SudoPrefix("ls -l %s/%s 2>/dev/null |wc -l"), remoteFileDirName, remoteFileName)
+	remoteFileCommand := fmt.Sprintf(host.SudoPrefixIfNecessary("ls -l %s/%s 2>/dev/null |wc -l"), remoteFileDirName, remoteFileName)
 
 	out, _, err := c.Exec(remoteFileCommand, host)
 	defer func() {
@@ -584,7 +584,7 @@ func (c *connection) MkDirAll(path string, mode string, host Host) error {
 		mode = "775"
 	}
 	mkDstDir := fmt.Sprintf("mkdir -p -m %s %s || true", mode, path)
-	if _, _, err := c.Exec(SudoPrefix(mkDstDir), host); err != nil {
+	if _, _, err := c.Exec(host.SudoPrefixIfNecessary(mkDstDir), host); err != nil {
 		return err
 	}
 
@@ -600,5 +600,6 @@ func (c *connection) Chmod(path string, mode os.FileMode) error {
 }
 
 func SudoPrefix(cmd string) string {
+	cmd = strings.ReplaceAll(cmd, `"`, `\"`)
 	return fmt.Sprintf("sudo -E /bin/bash -c \"%s\"", cmd)
 }

--- a/pkg/core/module/base.go
+++ b/pkg/core/module/base.go
@@ -42,7 +42,7 @@ func (b *BaseModule) IsSkip() bool {
 	return b.Skip
 }
 
-func (b *BaseModule) Default(runtime connector.Runtime, pipelineCache *cache.Cache, moduleCache *cache.Cache) {
+func (b *BaseModule) Default(runtime connector.ModuleRuntime, pipelineCache *cache.Cache, moduleCache *cache.Cache) {
 	b.Runtime = runtime
 	b.PipelineCache = pipelineCache
 	b.ModuleCache = moduleCache

--- a/pkg/core/module/interface.go
+++ b/pkg/core/module/interface.go
@@ -20,11 +20,12 @@ import (
 	"bytetrade.io/web3os/installer/pkg/core/cache"
 	"bytetrade.io/web3os/installer/pkg/core/connector"
 	"bytetrade.io/web3os/installer/pkg/core/ending"
+	"bytetrade.io/web3os/installer/pkg/core/task"
 )
 
 type Module interface {
 	IsSkip() bool
-	Default(runtime connector.Runtime, pipelineCache *cache.Cache, moduleCache *cache.Cache)
+	Default(runtime connector.ModuleRuntime, pipelineCache *cache.Cache, moduleCache *cache.Cache)
 	Init()
 	Is() string
 	Run(result *ending.ModuleResult)
@@ -34,4 +35,9 @@ type Module interface {
 	AppendPostHook(h PostHookInterface)
 	CallPostHook(result *ending.ModuleResult) error
 	GetName() string
+}
+
+type TaskModule interface {
+	Module
+	GetTasks() []task.Interface
 }

--- a/pkg/core/module/task_module.go
+++ b/pkg/core/module/task_module.go
@@ -40,6 +40,10 @@ func (b *BaseTaskModule) Is() string {
 	return TaskModuleType
 }
 
+func (b *BaseTaskModule) GetTasks() []task.Interface {
+	return b.Tasks
+}
+
 func (b *BaseTaskModule) Run(result *ending.ModuleResult) {
 	for i := range b.Tasks {
 		t := b.Tasks[i]

--- a/pkg/core/prepare/file_check.go
+++ b/pkg/core/prepare/file_check.go
@@ -25,7 +25,10 @@ type FileExist struct {
 }
 
 func (f *FileExist) PreCheck(runtime connector.Runtime) (bool, error) {
-	exist := runtime.GetRunner().Host.FileExist(f.FilePath)
+	exist, err := runtime.GetRunner().FileExist(f.FilePath)
+	if err != nil {
+		return false, err
+	}
 	if f.Not {
 		return !exist, nil
 	}

--- a/pkg/core/task/local_task.go
+++ b/pkg/core/task/local_task.go
@@ -25,7 +25,6 @@ import (
 
 	"bytetrade.io/web3os/installer/pkg/core/action"
 	"bytetrade.io/web3os/installer/pkg/core/cache"
-	"bytetrade.io/web3os/installer/pkg/core/common"
 	"bytetrade.io/web3os/installer/pkg/core/connector"
 	"bytetrade.io/web3os/installer/pkg/core/ending"
 	"bytetrade.io/web3os/installer/pkg/core/logger"
@@ -101,13 +100,7 @@ func (l *LocalTask) Execute() *ending.TaskResult {
 		return l.TaskResult
 	}
 
-	si := l.Runtime.GetSystemInfo()
-	host := &connector.BaseHost{
-		Name: common.LocalHost,
-		Arch: si.GetOsArch(),
-		Os:   si.GetOsType(),
-	}
-
+	host := l.Runtime.GetLocalHost()
 	selfRuntime := l.Runtime.Copy()
 	l.RunWithTimeout(selfRuntime, host)
 

--- a/pkg/core/util/cmd.go
+++ b/pkg/core/util/cmd.go
@@ -15,8 +15,8 @@ import (
 func ExecWithContext(ctx context.Context, name string, printOutput bool, printLine bool) (stdout string, code int, err error) {
 	exitCode := 0
 
-	logger.Infof("[exec] try to exec CMD: %s", name)
-	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", name)
+	logger.Debugf("[exec] try to exec CMD: %s", name)
+	cmd := exec.CommandContext(ctx, "/bin/bash", "-c", name)
 	out, err := cmd.StdoutPipe()
 	if err != nil {
 		return "", exitCode, err
@@ -73,7 +73,7 @@ func ExecWithContext(ctx context.Context, name string, printOutput bool, printLi
 		fmt.Printf("[exec] CMD: %s, OUTPUT: \n%s\n", cmd.String(), res)
 	}
 
-	logger.Infof("[exec] CMD: %s, OUTPUT: %s", cmd.String(), res)
+	logger.Debugf("[exec] CMD: %s, OUTPUT: %s", cmd.String(), res)
 	return res, exitCode, errors.Wrapf(err, "Failed to exec command: %s \n%s", cmd, res)
 }
 
@@ -81,7 +81,7 @@ func Exec(ctx context.Context, name string, printOutput bool, printLine bool) (s
 	exitCode := 0
 
 	logger.Debugf("[exec] try to exec CMD: %s", name)
-	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", name)
+	cmd := exec.CommandContext(ctx, "/bin/bash", "-c", name)
 	out, err := cmd.StdoutPipe()
 	if err != nil {
 		return "", exitCode, err

--- a/pkg/daemon/task.go
+++ b/pkg/daemon/task.go
@@ -33,12 +33,12 @@ func (g *InstallTerminusdBinary) Execute(runtime connector.Runtime) error {
 	path := binary.FilePath(g.BaseDir)
 
 	dst := filepath.Join(common.TmpDir, binary.Filename)
-	if err := runtime.GetRunner().Host.Scp(path, dst); err != nil {
+	if err := runtime.GetRunner().Scp(path, dst); err != nil {
 		return errors.Wrap(errors.WithStack(err), "sync olaresd tar.gz failed")
 	}
 
 	installCmd := fmt.Sprintf("tar -zxf %s && cp -f olaresd /usr/local/bin/ && chmod +x /usr/local/bin/olaresd && rm -rf olaresd*", dst)
-	if _, err := runtime.GetRunner().Host.SudoCmd(installCmd, false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(installCmd, false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "install olaresd binaries failed")
 	}
 	return nil
@@ -108,7 +108,7 @@ type EnableTerminusdService struct {
 }
 
 func (e *EnableTerminusdService) Execute(runtime connector.Runtime) error {
-	if _, err := runtime.GetRunner().Host.SudoCmd("systemctl enable --now olaresd",
+	if _, err := runtime.GetRunner().SudoCmd("systemctl enable --now olaresd",
 		false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "enable olaresd failed")
 	}
@@ -120,7 +120,7 @@ type DisableTerminusdService struct {
 }
 
 func (s *DisableTerminusdService) Execute(runtime connector.Runtime) error {
-	if _, err := runtime.GetRunner().Host.SudoCmd("systemctl disable --now olaresd", false, true); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd("systemctl disable --now olaresd", false, true); err != nil {
 		return errors.Wrap(errors.WithStack(err), "disable olaresd failed")
 	}
 	return nil
@@ -133,7 +133,7 @@ type UninstallTerminusd struct {
 func (r *UninstallTerminusd) Execute(runtime connector.Runtime) error {
 	svcpath := filepath.Join("/etc/systemd/system", templates.TerminusdService.Name())
 	svcenvpath := filepath.Join("/etc/systemd/system", templates.TerminusdEnv.Name())
-	if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("rm -rf %s && rm -rf %s && rm -rf /usr/local/bin/olaresd", svcpath, svcenvpath), false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("rm -rf %s && rm -rf %s && rm -rf /usr/local/bin/olaresd", svcpath, svcenvpath), false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "remove olaresd failed")
 	}
 	return nil

--- a/pkg/etcd/certs.go
+++ b/pkg/etcd/certs.go
@@ -120,7 +120,7 @@ func (f *FetchCerts) Execute(runtime connector.Runtime) error {
 	c := v.(*EtcdCluster)
 
 	if c.clusterExist {
-		certs, err := runtime.GetRunner().Host.SudoCmd("ls /etc/ssl/etcd/ssl/ | grep .pem", false, false)
+		certs, err := runtime.GetRunner().SudoCmd("ls /etc/ssl/etcd/ssl/ | grep .pem", false, false)
 		if err != nil {
 			return errors.Wrap(err, "failed to find certificate files")
 		}
@@ -132,7 +132,7 @@ func (f *FetchCerts) Execute(runtime connector.Runtime) error {
 		certsList := strings.Split(certs, split)
 		if len(certsList) > 0 {
 			for _, cert := range certsList {
-				if err := runtime.GetRunner().Host.Fetch(filepath.Join(dst, cert), filepath.Join(src, cert), false, false); err != nil {
+				if err := runtime.GetRunner().Fetch(filepath.Join(dst, cert), filepath.Join(src, cert), false, false); err != nil {
 					return errors.Wrap(err, fmt.Sprintf("Fetch %s failed", filepath.Join(src, cert)))
 				}
 			}

--- a/pkg/filesystem/task.go
+++ b/pkg/filesystem/task.go
@@ -32,21 +32,24 @@ type ChownFileAndDir struct {
 }
 
 func (c *ChownFileAndDir) Execute(runtime connector.Runtime) error {
-	exist := runtime.GetRunner().Host.FileExist(c.Path)
+	exist, err := runtime.GetRunner().FileExist(c.Path)
+	if err != nil {
+		return err
+	}
 
 	if exist {
-		userId, err := runtime.GetRunner().Host.Cmd("echo $(id -u)", false, false)
+		userId, err := runtime.GetRunner().Cmd("echo $(id -u)", false, false)
 		if err != nil {
 			return errors.Wrap(errors.WithStack(err), "get user id failed")
 		}
 
-		userGroupId, err := runtime.GetRunner().Host.Cmd("echo $(id -g)", false, false)
+		userGroupId, err := runtime.GetRunner().Cmd("echo $(id -g)", false, false)
 		if err != nil {
 			return errors.Wrap(errors.WithStack(err), "get user group id failed")
 		}
 
 		chownKubeConfig := fmt.Sprintf("chown -R %s:%s %s", userId, userGroupId, c.Path)
-		if _, err := runtime.GetRunner().Host.SudoCmd(chownKubeConfig, false, false); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd(chownKubeConfig, false, false); err != nil {
 			return errors.Wrapf(errors.WithStack(err), "chown user %s failed", c.Path)
 		}
 	}

--- a/pkg/gpu/prepares.go
+++ b/pkg/gpu/prepares.go
@@ -102,10 +102,10 @@ type NvidiaGraphicsCard struct {
 }
 
 func (p *NvidiaGraphicsCard) PreCheck(runtime connector.Runtime) (bool, error) {
-	if runtime.GetRunner().Host.GetOs() == common.Darwin {
+	if runtime.RemoteHost().GetOs() == common.Darwin {
 		return false, nil
 	}
-	output, err := runtime.GetRunner().Host.SudoCmd(
+	output, err := runtime.GetRunner().SudoCmd(
 		"lspci | grep -i vga | grep -i nvidia", false, false)
 	if err != nil {
 		logger.Error("try to find nvidia graphics card error", err)

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -112,14 +112,14 @@ func (images *Images) PullImages(runtime connector.Runtime, kubeConf *common.Kub
 			(host.IsRole(common.Master) || host.IsRole(common.Worker)) && image.Group == kubekeyapiv1alpha2.K8s && image.Enable,
 			host.IsRole(common.ETCD) && image.Group == kubekeyapiv1alpha2.Etcd && image.Enable:
 
-			if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("%s inspecti -q %s", pullCmd, image.ImageName()), false, false); err == nil {
+			if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("%s inspecti -q %s", pullCmd, image.ImageName()), false, false); err == nil {
 				logger.Infof("%s pull image %s exists", pullCmd, image.ImageName())
 				continue
 			}
 
 			// fmt.Printf("%s downloading image %s\n", pullCmd, image.ImageName())
 			logger.Debugf("%s pull image: %s - %s", host.GetName(), image.ImageName(), runtime.RemoteHost().GetName())
-			if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("%s pull %s", pullCmd, image.ImageName()), false, false); err != nil {
+			if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("%s pull %s", pullCmd, image.ImageName()), false, false); err != nil {
 				return errors.Wrap(err, "pull image failed")
 			}
 		default:
@@ -178,7 +178,7 @@ func (i LocalImages) LoadImages(runtime connector.Runtime, kubeConf *common.Kube
 				// continue if load image error
 				if err := retry(func() error {
 					logger.Infof("preloading image: %s", fileName)
-					if stdout, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("env PATH=$PATH gunzip -c %s | %s", image.Filename, loadCmd), false, false); err != nil {
+					if stdout, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("env PATH=$PATH gunzip -c %s | %s", image.Filename, loadCmd), false, false); err != nil {
 						return fmt.Errorf("%s", fileName)
 					} else {
 						logger.Infof("%s in %s\n", formatLoadImageRes(stdout, fileName), time.Since(start))
@@ -202,7 +202,7 @@ func (i LocalImages) LoadImages(runtime connector.Runtime, kubeConf *common.Kube
 
 				if err := retry(func() error {
 					logger.Infof("preloading image: %s", fileName)
-					if stdout, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("env PATH=$PATH %s %s", loadCmd, image.Filename), false, false); err != nil {
+					if stdout, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("env PATH=$PATH %s %s", loadCmd, image.Filename), false, false); err != nil {
 						return fmt.Errorf("%s", fileName)
 					} else {
 						logger.Infof("%s in %s\n", formatLoadImageRes(stdout, fileName), time.Since(start))

--- a/pkg/images/load.go
+++ b/pkg/images/load.go
@@ -123,7 +123,7 @@ func (t *LoadImages) Execute(runtime connector.Runtime) (reserr error) {
 			loadParm = "--snapshotter=zfs"
 		}
 
-		if runtime.GetRunner().Host.GetOs() == common.Darwin {
+		if runtime.RemoteHost().GetOs() == common.Darwin {
 			if HasSuffixI(imgFileName, ".tar.gz", ".tgz") {
 				loadCmd = fmt.Sprintf("gunzip -c %s | %s -p %s image load -", imageFileName, minikubepath, minikubeprofile)
 			} else {
@@ -146,7 +146,7 @@ func (t *LoadImages) Execute(runtime connector.Runtime) (reserr error) {
 		}
 
 		if err := retry(func() error {
-			if _, err := runtime.GetRunner().Host.SudoCmd(loadCmd, false, false); err != nil {
+			if _, err := runtime.GetRunner().SudoCmd(loadCmd, false, false); err != nil {
 				return fmt.Errorf("%s(%s) error: %v", imageRepoTag, imgFileName, err)
 			} else {
 				logger.Infof("(%d/%d) imported image: %s, time: %s", index+1, len(missingImages), imageRepoTag, time.Since(start))

--- a/pkg/images/prepares.go
+++ b/pkg/images/prepares.go
@@ -42,10 +42,10 @@ type ContainerdInstalled struct {
 }
 
 func (c *ContainerdInstalled) PreCheck(runtime connector.Runtime) (bool, error) {
-	if runtime.GetRunner().Host.GetOs() == common.Darwin {
+	if runtime.RemoteHost().GetOs() == common.Darwin {
 		return true, nil
 	}
-	output, err := runtime.GetRunner().Host.SudoCmd(
+	output, err := runtime.GetRunner().SudoCmd(
 		"if [ -z $(which containerd) ] || [ ! -e /run/containerd/containerd.sock ]; "+
 			"then echo 'not exist'; "+
 			"fi", false, false)

--- a/pkg/k3s/k3s_status.go
+++ b/pkg/k3s/k3s_status.go
@@ -42,7 +42,7 @@ func NewK3sStatus() *K3sStatus {
 
 func (k *K3sStatus) SearchVersion(runtime connector.Runtime) error {
 	cmd := "k3s --version | grep 'k3s' | awk '{print $3}'"
-	if output, err := runtime.GetRunner().Host.Cmd(cmd, true, false); err != nil {
+	if output, err := runtime.GetRunner().Cmd(cmd, true, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "search current version failed")
 	} else {
 		k.Version = output
@@ -52,7 +52,7 @@ func (k *K3sStatus) SearchVersion(runtime connector.Runtime) error {
 
 func (k *K3sStatus) SearchKubeConfig(runtime connector.Runtime) error {
 	kubeCfgCmd := "cat /etc/rancher/k3s/k3s.yaml"
-	if kubeConfigStr, err := runtime.GetRunner().Host.SudoCmd(kubeCfgCmd, false, false); err != nil {
+	if kubeConfigStr, err := runtime.GetRunner().SudoCmd(kubeCfgCmd, false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "search cluster kubeconfig failed")
 	} else {
 		k.KubeConfig = kubeConfigStr
@@ -62,7 +62,7 @@ func (k *K3sStatus) SearchKubeConfig(runtime connector.Runtime) error {
 
 func (k *K3sStatus) SearchNodeToken(runtime connector.Runtime) error {
 	nodeTokenBase64Cmd := "cat /var/lib/rancher/k3s/server/node-token"
-	output, err := runtime.GetRunner().Host.SudoCmd(nodeTokenBase64Cmd, true, false)
+	output, err := runtime.GetRunner().SudoCmd(nodeTokenBase64Cmd, true, false)
 	if err != nil {
 		return errors.Wrap(errors.WithStack(err), "get cluster node token failed")
 	}
@@ -71,7 +71,7 @@ func (k *K3sStatus) SearchNodeToken(runtime connector.Runtime) error {
 }
 
 func (k *K3sStatus) SearchInfo(runtime connector.Runtime) error {
-	output, err := runtime.GetRunner().Host.SudoCmd(
+	output, err := runtime.GetRunner().SudoCmd(
 		"/usr/local/bin/kubectl --no-headers=true get nodes -o custom-columns=:metadata.name,:status.nodeInfo.kubeletVersion,:status.addresses",
 		true, false)
 	if err != nil {
@@ -120,4 +120,8 @@ func (k *K3sStatus) LoadKubeConfig(runtime connector.Runtime, kubeConf *common.K
 		return err
 	}
 	return nil
+}
+
+func (k *K3sStatus) GetNodesInfo() map[string]string {
+	return k.NodesInfo
 }

--- a/pkg/k3s/module.go
+++ b/pkg/k3s/module.go
@@ -17,6 +17,7 @@
 package k3s
 
 import (
+	"bytetrade.io/web3os/installer/pkg/kubernetes"
 	"path/filepath"
 	"strings"
 	"time"
@@ -245,7 +246,7 @@ func (i *InstallKubeBinariesModule) Init() {
 		Name:    "SyncKubeBinary(k3s)",
 		Desc:    "Synchronize k3s binaries",
 		Hosts:   i.Runtime.GetHostsByRole(common.K8s),
-		Prepare: &NodeInCluster{Not: true},
+		Prepare: &kubernetes.NodeInCluster{Not: true},
 		Action: &SyncKubeBinary{
 			ManifestAction: manifest.ManifestAction{
 				BaseDir:  i.BaseDir,
@@ -260,7 +261,7 @@ func (i *InstallKubeBinariesModule) Init() {
 		Name:    "GenerateK3sKillAllScript",
 		Desc:    "Generate k3s killall.sh script",
 		Hosts:   i.Runtime.GetHostsByRole(common.K8s),
-		Prepare: &NodeInCluster{Not: true},
+		Prepare: &kubernetes.NodeInCluster{Not: true},
 		Action: &action.Template{
 			Name:     "GenerateK3sKillAllScript",
 			Template: templates.K3sKillallScript,
@@ -274,7 +275,7 @@ func (i *InstallKubeBinariesModule) Init() {
 		Name:    "GenerateK3sUninstallScript",
 		Desc:    "Generate k3s uninstall script",
 		Hosts:   i.Runtime.GetHostsByRole(common.K8s),
-		Prepare: &NodeInCluster{Not: true},
+		Prepare: &kubernetes.NodeInCluster{Not: true},
 		Action: &action.Template{
 			Name:     "GenerateK3sUninstallScript",
 			Template: templates.K3sUninstallScript,
@@ -288,7 +289,7 @@ func (i *InstallKubeBinariesModule) Init() {
 		Name:     "ChmodScript(k3s)",
 		Desc:     "Chmod +x k3s script ",
 		Hosts:    i.Runtime.GetHostsByRole(common.K8s),
-		Prepare:  &NodeInCluster{Not: true},
+		Prepare:  &kubernetes.NodeInCluster{Not: true},
 		Action:   new(ChmodScript),
 		Parallel: true,
 		Retry:    2,
@@ -440,7 +441,7 @@ func (j *JoinNodesModule) Init() {
 		Desc:  "Generate k3s Service",
 		Hosts: j.Runtime.GetHostsByRole(common.K8s),
 		Prepare: &prepare.PrepareCollection{
-			&NodeInCluster{Not: true},
+			&kubernetes.NodeInCluster{Not: true},
 		},
 		Action:   new(GenerateK3sService),
 		Parallel: true,
@@ -451,7 +452,7 @@ func (j *JoinNodesModule) Init() {
 		Desc:  "Generate k3s service env",
 		Hosts: j.Runtime.GetHostsByRole(common.K8s),
 		Prepare: &prepare.PrepareCollection{
-			&NodeInCluster{Not: true},
+			&kubernetes.NodeInCluster{Not: true},
 		},
 		Action:   new(GenerateK3sServiceEnv),
 		Parallel: true,
@@ -462,7 +463,7 @@ func (j *JoinNodesModule) Init() {
 		Desc:  "Generate k3s registry config",
 		Hosts: j.Runtime.GetHostsByRole(common.K8s),
 		Prepare: &prepare.PrepareCollection{
-			&NodeInCluster{Not: true},
+			&kubernetes.NodeInCluster{Not: true},
 			&UsePrivateRegstry{Not: false},
 		},
 		Action:   new(GenerateK3sRegistryConfig),
@@ -474,7 +475,7 @@ func (j *JoinNodesModule) Init() {
 		Desc:  "Enable k3s service",
 		Hosts: j.Runtime.GetHostsByRole(common.K8s),
 		Prepare: &prepare.PrepareCollection{
-			&NodeInCluster{Not: true},
+			&kubernetes.NodeInCluster{Not: true},
 		},
 		Action:   new(EnableK3sService),
 		Parallel: false,
@@ -485,7 +486,7 @@ func (j *JoinNodesModule) Init() {
 		Desc:  "Copy k3s.yaml to ~/.kube/config",
 		Hosts: j.Runtime.GetHostsByRole(common.Master),
 		Prepare: &prepare.PrepareCollection{
-			&NodeInCluster{Not: true},
+			&kubernetes.NodeInCluster{Not: true},
 		},
 		Action:   new(CopyK3sKubeConfig),
 		Parallel: true,
@@ -496,7 +497,7 @@ func (j *JoinNodesModule) Init() {
 		Desc:  "Synchronize kube config to worker",
 		Hosts: j.Runtime.GetHostsByRole(common.Worker),
 		Prepare: &prepare.PrepareCollection{
-			&NodeInCluster{Not: true},
+			&kubernetes.NodeInCluster{Not: true},
 			new(common.OnlyWorker),
 		},
 		Action:   new(SyncKubeConfigToWorker),
@@ -508,7 +509,7 @@ func (j *JoinNodesModule) Init() {
 		Desc:  "Add master taint",
 		Hosts: j.Runtime.GetHostsByRole(common.Master),
 		Prepare: &prepare.PrepareCollection{
-			&NodeInCluster{Not: true},
+			&kubernetes.NodeInCluster{Not: true},
 			&common.IsWorker{Not: true},
 		},
 		Action:   new(AddMasterTaint),
@@ -522,7 +523,7 @@ func (j *JoinNodesModule) Init() {
 		Desc:  "Add worker label",
 		Hosts: j.Runtime.GetHostsByRole(common.K8s),
 		Prepare: &prepare.PrepareCollection{
-			&NodeInCluster{Not: true},
+			&kubernetes.NodeInCluster{Not: true},
 			new(common.IsWorker),
 		},
 		Action:   new(AddWorkerLabel),

--- a/pkg/k3s/prepares.go
+++ b/pkg/k3s/prepares.go
@@ -25,28 +25,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-type NodeInCluster struct {
-	common.KubePrepare
-	Not bool
-}
-
-func (n *NodeInCluster) PreCheck(runtime connector.Runtime) (bool, error) {
-	host := runtime.RemoteHost()
-	if v, ok := n.PipelineCache.Get(common.ClusterStatus); ok {
-		cluster := v.(*K3sStatus)
-		var versionOk bool
-		if res, ok := cluster.NodesInfo[host.GetName()]; ok && res != "" {
-			versionOk = true
-		}
-		_, ipOk := cluster.NodesInfo[host.GetInternalAddress()]
-		if n.Not {
-			return !(versionOk || ipOk), nil
-		}
-		return versionOk || ipOk, nil
-	}
-	return false, errors.New("get k3s cluster status by pipeline cache failed")
-}
-
 type ClusterIsExist struct {
 	common.KubePrepare
 	Not bool

--- a/pkg/k3s/tasks.go
+++ b/pkg/k3s/tasks.go
@@ -56,7 +56,10 @@ type GetClusterStatus struct {
 }
 
 func (g *GetClusterStatus) Execute(runtime connector.Runtime) error {
-	var exist = runtime.GetRunner().Host.FileExist("/etc/systemd/system/k3s.service")
+	exist, err := runtime.GetRunner().FileExist("/etc/systemd/system/k3s.service")
+	if err != nil {
+		return err
+	}
 
 	if !exist {
 		g.PipelineCache.Set(common.ClusterExist, false)
@@ -116,10 +119,10 @@ func (s *SyncKubeBinary) Execute(runtime connector.Runtime) error {
 		case "cni-plugins-k3s":
 			dst := filepath.Join(common.TmpDir, fileName)
 			logger.Debugf("SyncKubeBinary cp %s from %s to %s", name, path, dst)
-			if err := runtime.GetRunner().Host.Scp(path, dst); err != nil {
+			if err := runtime.GetRunner().Scp(path, dst); err != nil {
 				return errors.Wrap(errors.WithStack(err), fmt.Sprintf("sync kube binaries failed"))
 			}
-			if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("tar -zxf %s -C /opt/cni/bin", dst), false, false); err != nil {
+			if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("tar -zxf %s -C /opt/cni/bin", dst), false, false); err != nil {
 				return err
 			}
 		case "helm":
@@ -127,22 +130,22 @@ func (s *SyncKubeBinary) Execute(runtime connector.Runtime) error {
 			dst := filepath.Join(common.TmpDir, fileName)
 			untarDst := filepath.Join(common.TmpDir, strings.TrimSuffix(fileName, ".tar.gz"))
 			logger.Debugf("SyncKubeBinary cp %s from %s to %s", name, path, dst)
-			if err := runtime.GetRunner().Host.Scp(path, dst); err != nil {
+			if err := runtime.GetRunner().Scp(path, dst); err != nil {
 				return errors.Wrap(errors.WithStack(err), fmt.Sprintf("sync kube binaries failed"))
 			}
 
 			cmd := fmt.Sprintf("mkdir -p %s && tar -zxf %s -C %s && cd %s/linux-* && mv ./helm /usr/local/bin/.",
 				untarDst, dst, untarDst, untarDst)
-			if _, err := runtime.GetRunner().Host.SudoCmd(cmd, false, false); err != nil {
+			if _, err := runtime.GetRunner().SudoCmd(cmd, false, false); err != nil {
 				return err
 			}
 		default:
 			dst := filepath.Join(common.BinDir, fileName)
 			logger.Debugf("SyncKubeBinary cp %s from %s to %s", name, path, dst)
-			if err := runtime.GetRunner().Host.SudoScp(path, dst); err != nil {
+			if err := runtime.GetRunner().SudoScp(path, dst); err != nil {
 				return errors.Wrap(errors.WithStack(err), fmt.Sprintf("sync kube binaries failed"))
 			}
-			if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("chmod +x %s", dst), false, false); err != nil {
+			if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("chmod +x %s", dst), false, false); err != nil {
 				return err
 			}
 		}
@@ -153,7 +156,7 @@ func (s *SyncKubeBinary) Execute(runtime connector.Runtime) error {
 	for _, binary := range binaries {
 		createLinkCMDs = append(createLinkCMDs, fmt.Sprintf("ln -snf /usr/local/bin/k3s /usr/local/bin/%s", binary))
 	}
-	if _, err := runtime.GetRunner().Host.SudoCmd(strings.Join(createLinkCMDs, " && "), false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(strings.Join(createLinkCMDs, " && "), false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "create ctl tool link failed")
 	}
 
@@ -168,11 +171,11 @@ func (c *ChmodScript) Execute(runtime connector.Runtime) error {
 	killAllScript := filepath.Join("/usr/local/bin", templates.K3sKillallScript.Name())
 	uninstallScript := filepath.Join("/usr/local/bin", templates.K3sUninstallScript.Name())
 
-	if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("chmod +x %s", killAllScript),
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("chmod +x %s", killAllScript),
 		false, false); err != nil {
 		return err
 	}
-	if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("chmod +x %s", uninstallScript),
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("chmod +x %s", uninstallScript),
 		false, false); err != nil {
 		return err
 	}
@@ -342,7 +345,7 @@ type EnableK3sService struct {
 }
 
 func (e *EnableK3sService) Execute(runtime connector.Runtime) error {
-	if _, err := runtime.GetRunner().Host.SudoCmd("systemctl daemon-reload && systemctl enable --now k3s",
+	if _, err := runtime.GetRunner().SudoCmd("systemctl daemon-reload && systemctl enable --now k3s",
 		false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "enable k3s failed")
 	}
@@ -394,46 +397,46 @@ func (c *CopyK3sKubeConfig) Execute(runtime connector.Runtime) error {
 	chmodKubeConfigCmd := "chmod 0600 /root/.kube/config"
 
 	cmd := strings.Join([]string{createConfigDirCmd, getKubeConfigCmd, chmodKubeConfigCmd}, " && ")
-	if _, err := runtime.GetRunner().Host.SudoCmd(cmd, false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(cmd, false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "copy k3s kube config failed")
 	}
 
 	userMkdir := "mkdir -p $HOME/.kube"
-	if _, err := runtime.GetRunner().Host.Cmd(userMkdir, false, false); err != nil {
+	if _, err := runtime.GetRunner().Cmd(userMkdir, false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "user mkdir $HOME/.kube failed")
 	}
 
 	userCopyKubeConfig := "cp -f /etc/rancher/k3s/k3s.yaml $HOME/.kube/config"
-	if _, err := runtime.GetRunner().Host.SudoCmd(userCopyKubeConfig, false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(userCopyKubeConfig, false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "user copy /etc/rancher/k3s/k3s.yaml to $HOME/.kube/config failed")
 	}
 
-	if _, err := runtime.GetRunner().Host.SudoCmd("chmod 0600 $HOME/.kube/config", false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd("chmod 0600 $HOME/.kube/config", false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "chmod k3s $HOME/.kube/config 0600 failed")
 	}
 
-	// userId, err := runtime.GetRunner().Host.Cmd("echo $(id -u)", false, false)
+	// userId, err := runtime.GetRunner().Cmd("echo $(id -u)", false, false)
 	// if err != nil {
 	// 	return errors.Wrap(errors.WithStack(err), "get user id failed")
 	// }
 
-	// userGroupId, err := runtime.GetRunner().Host.Cmd("echo $(id -g)", false, false)
+	// userGroupId, err := runtime.GetRunner().Cmd("echo $(id -g)", false, false)
 	// if err != nil {
 	// 	return errors.Wrap(errors.WithStack(err), "get user group id failed")
 	// }
 
-	userId, err := runtime.GetRunner().Host.Cmd("echo $SUDO_UID", false, false)
+	userId, err := runtime.GetRunner().Cmd("echo $SUDO_UID", false, false)
 	if err != nil {
 		return errors.Wrap(errors.WithStack(err), "get user id failed")
 	}
 
-	userGroupId, err := runtime.GetRunner().Host.Cmd("echo $SUDO_GID", false, false)
+	userGroupId, err := runtime.GetRunner().Cmd("echo $SUDO_GID", false, false)
 	if err != nil {
 		return errors.Wrap(errors.WithStack(err), "get user group id failed")
 	}
 
 	chownKubeConfig := fmt.Sprintf("chown -R %s:%s $HOME/.kube", userId, userGroupId)
-	if _, err := runtime.GetRunner().Host.SudoCmd(chownKubeConfig, false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(chownKubeConfig, false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "chown user kube config failed")
 	}
 	return nil
@@ -450,7 +453,7 @@ func (a *AddMasterTaint) Execute(runtime connector.Runtime) error {
 		"/usr/local/bin/kubectl taint nodes %s node-role.kubernetes.io/master=effect:NoSchedule --overwrite",
 		host.GetName())
 
-	if _, err := runtime.GetRunner().Host.SudoCmd(cmd, false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(cmd, false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "add master NoSchedule taint failed")
 	}
 	return nil
@@ -469,7 +472,7 @@ func (a *AddWorkerLabel) Execute(runtime connector.Runtime) error {
 
 	var out string
 	var err error
-	if out, err = runtime.GetRunner().Host.SudoCmd(cmd, false, false); err != nil {
+	if out, err = runtime.GetRunner().SudoCmd(cmd, false, false); err != nil {
 		return fmt.Errorf("waiting for node ready")
 		// return errors.Wrap(errors.WithStack(err), "add master NoSchedule taint failed")
 	}
@@ -486,7 +489,7 @@ func (s *SyncKubeConfigToWorker) Execute(runtime connector.Runtime) error {
 		cluster := v.(*K3sStatus)
 
 		createConfigDirCmd := "mkdir -p /root/.kube"
-		if _, err := runtime.GetRunner().Host.SudoCmd(createConfigDirCmd, false, false); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd(createConfigDirCmd, false, false); err != nil {
 			return errors.Wrap(errors.WithStack(err), "create .kube dir failed")
 		}
 
@@ -497,46 +500,46 @@ func (s *SyncKubeConfigToWorker) Execute(runtime connector.Runtime) error {
 		newKubeConfig := strings.Replace(cluster.KubeConfig, oldServer, newServer, -1)
 
 		syncKubeConfigForRootCmd := fmt.Sprintf("echo '%s' > %s", newKubeConfig, "/root/.kube/config")
-		if _, err := runtime.GetRunner().Host.SudoCmd(syncKubeConfigForRootCmd, false, false); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd(syncKubeConfigForRootCmd, false, false); err != nil {
 			return errors.Wrap(errors.WithStack(err), "sync kube config for root failed")
 		}
 
-		if _, err := runtime.GetRunner().Host.SudoCmd("chmod 0600 /root/.kube/config", false, false); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd("chmod 0600 /root/.kube/config", false, false); err != nil {
 			return errors.Wrap(errors.WithStack(err), "chmod k3s $HOME/.kube/config failed")
 		}
 
 		userConfigDirCmd := "mkdir -p $HOME/.kube"
-		if _, err := runtime.GetRunner().Host.Cmd(userConfigDirCmd, false, false); err != nil {
+		if _, err := runtime.GetRunner().Cmd(userConfigDirCmd, false, false); err != nil {
 			return errors.Wrap(errors.WithStack(err), "user mkdir $HOME/.kube failed")
 		}
 
 		syncKubeConfigForUserCmd := fmt.Sprintf("echo '%s' > %s", newKubeConfig, "$HOME/.kube/config")
-		if _, err := runtime.GetRunner().Host.Cmd(syncKubeConfigForUserCmd, false, false); err != nil {
+		if _, err := runtime.GetRunner().Cmd(syncKubeConfigForUserCmd, false, false); err != nil {
 			return errors.Wrap(errors.WithStack(err), "sync kube config for normal user failed")
 		}
 
-		// userId, err := runtime.GetRunner().Host.Cmd("echo $(id -u)", false, false)
+		// userId, err := runtime.GetRunner().Cmd("echo $(id -u)", false, false)
 		// if err != nil {
 		// 	return errors.Wrap(errors.WithStack(err), "get user id failed")
 		// }
 
-		// userGroupId, err := runtime.GetRunner().Host.Cmd("echo $(id -g)", false, false)
+		// userGroupId, err := runtime.GetRunner().Cmd("echo $(id -g)", false, false)
 		// if err != nil {
 		// 	return errors.Wrap(errors.WithStack(err), "get user group id failed")
 		// }
 
-		userId, err := runtime.GetRunner().Host.Cmd("echo $SUDO_UID", false, false)
+		userId, err := runtime.GetRunner().Cmd("echo $SUDO_UID", false, false)
 		if err != nil {
 			return errors.Wrap(errors.WithStack(err), "get user id failed")
 		}
 
-		userGroupId, err := runtime.GetRunner().Host.Cmd("echo $SUDO_GID", false, false)
+		userGroupId, err := runtime.GetRunner().Cmd("echo $SUDO_GID", false, false)
 		if err != nil {
 			return errors.Wrap(errors.WithStack(err), "get user group id failed")
 		}
 
 		chownKubeConfig := fmt.Sprintf("chown -R %s:%s -R $HOME/.kube", userId, userGroupId)
-		if _, err := runtime.GetRunner().Host.SudoCmd(chownKubeConfig, false, false); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd(chownKubeConfig, false, false); err != nil {
 			return errors.Wrap(errors.WithStack(err), "chown user kube config failed")
 		}
 	}
@@ -548,7 +551,7 @@ type ExecKillAllScript struct {
 }
 
 func (t *ExecKillAllScript) Execute(runtime connector.Runtime) error {
-	if _, err := runtime.GetRunner().Host.SudoCmd("systemctl daemon-reload && /usr/local/bin/k3s-killall.sh",
+	if _, err := runtime.GetRunner().SudoCmd("systemctl daemon-reload && /usr/local/bin/k3s-killall.sh",
 		true, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "add master NoSchedule taint failed")
 	}
@@ -560,7 +563,7 @@ type ExecUninstallScript struct {
 }
 
 func (e *ExecUninstallScript) Execute(runtime connector.Runtime) error {
-	if _, err := runtime.GetRunner().Host.SudoCmd("systemctl daemon-reload && /usr/local/bin/k3s-uninstall.sh",
+	if _, err := runtime.GetRunner().SudoCmd("systemctl daemon-reload && /usr/local/bin/k3s-uninstall.sh",
 		true, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "add master NoSchedule taint failed")
 	}
@@ -692,7 +695,7 @@ type UninstallK3s struct {
 
 func (t *UninstallK3s) Execute(runtime connector.Runtime) error {
 	var scriptPath = path.Join(common.BinDir, "k3s-uninstall.sh")
-	if _, err := runtime.GetRunner().Host.CmdExt(scriptPath, false, true); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(scriptPath, false, true); err != nil {
 		return err
 	}
 	return nil
@@ -716,7 +719,7 @@ func (t *DeleteCalicoCNI) Execute(runtime connector.Runtime) error {
 		if len(name) < 5 || name[0:4] != "cali" {
 			continue
 		}
-		if _, err := runtime.GetRunner().Host.CmdExt(fmt.Sprintf("ip link delete %s", name), false, false); err != nil {
+		if _, err := runtime.GetRunner().Cmd(fmt.Sprintf("ip link delete %s", name), false, false); err != nil {
 			logger.Errorf("delete ip link %s error %v", name, err)
 		}
 		time.Sleep(200 * time.Millisecond)

--- a/pkg/kubernetes/tasks.go
+++ b/pkg/kubernetes/tasks.go
@@ -112,7 +112,10 @@ type GetClusterStatus struct {
 }
 
 func (g *GetClusterStatus) Execute(runtime connector.Runtime) error {
-	exist := runtime.GetRunner().Host.FileExist("/etc/kubernetes/admin.conf")
+	exist, err := runtime.GetRunner().FileExist("/etc/kubernetes/admin.conf")
+	if err != nil {
+		return err
+	}
 	if !exist {
 		g.PipelineCache.Set(common.ClusterExist, false)
 		return nil
@@ -170,37 +173,37 @@ func (i *SyncKubeBinary) Execute(runtime connector.Runtime) error {
 		fileName := binary.Filename
 		switch name {
 		//case "kubelet":
-		//	if err := runtime.GetRunner().Host.Scp(binary.Path, fmt.Sprintf("%s/%s", common.TmpDir, binary.Name)); err != nil {
+		//	if err := runtime.GetRunner().Scp(binary.Path, fmt.Sprintf("%s/%s", common.TmpDir, binary.Name)); err != nil {
 		//		return errors.Wrap(errors.WithStack(err), fmt.Sprintf("sync kube binaries failed"))
 		//	}
 		case "cni-plugins-k8s":
 			dst := filepath.Join(common.TmpDir, fileName)
 			logger.Debugf("SyncKubeBinary cp %s from %s to %s", name, path, dst)
-			if err := runtime.GetRunner().Host.Scp(path, dst); err != nil {
+			if err := runtime.GetRunner().Scp(path, dst); err != nil {
 				return errors.Wrap(errors.WithStack(err), fmt.Sprintf("sync kube binaries failed"))
 			}
-			if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("tar -zxf %s -C /opt/cni/bin", dst), false, false); err != nil {
+			if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("tar -zxf %s -C /opt/cni/bin", dst), false, false); err != nil {
 				return err
 			}
 		case "helm":
 			dst := filepath.Join(common.TmpDir, fileName)
 			untarDst := filepath.Join(common.TmpDir, strings.TrimSuffix(fileName, ".tar.gz"))
 			logger.Debugf("SyncKubeBinary cp %s from %s to %s", name, path, dst)
-			if err := runtime.GetRunner().Host.Scp(path, dst); err != nil {
+			if err := runtime.GetRunner().Scp(path, dst); err != nil {
 				return errors.Wrap(errors.WithStack(err), fmt.Sprintf("sync kube binaries failed"))
 			}
 
 			cmd := fmt.Sprintf("mkdir -p %s && tar -zxf %s -C %s && cd %s/linux-* && mv ./helm /usr/local/bin/.",
 				untarDst, dst, untarDst, untarDst)
-			if _, err := runtime.GetRunner().Host.SudoCmd(cmd, false, false); err != nil {
+			if _, err := runtime.GetRunner().SudoCmd(cmd, false, false); err != nil {
 				return err
 			}
 		default:
 			dst := filepath.Join(common.BinDir, fileName)
-			if err := runtime.GetRunner().Host.SudoScp(path, dst); err != nil {
+			if err := runtime.GetRunner().SudoScp(path, dst); err != nil {
 				return errors.Wrap(errors.WithStack(err), fmt.Sprintf("sync kube binaries failed"))
 			}
-			if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("chmod +x %s", dst), false, false); err != nil {
+			if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("chmod +x %s", dst), false, false); err != nil {
 				return err
 			}
 		}
@@ -213,7 +216,7 @@ type SyncKubelet struct {
 }
 
 func (s *SyncKubelet) Execute(runtime connector.Runtime) error {
-	if _, err := runtime.GetRunner().Host.SudoCmd("chmod +x /usr/local/bin/kubelet", false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd("chmod +x /usr/local/bin/kubelet", false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "sync kubelet service failed")
 	}
 	return nil
@@ -243,7 +246,7 @@ type EnableKubelet struct {
 }
 
 func (e *EnableKubelet) Execute(runtime connector.Runtime) error {
-	if _, err := runtime.GetRunner().Host.SudoCmd("systemctl disable kubelet "+
+	if _, err := runtime.GetRunner().SudoCmd("systemctl disable kubelet "+
 		"&& systemctl enable kubelet "+
 		"&& ln -snf /usr/local/bin/kubelet /usr/bin/kubelet", false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "enable kubelet service failed")
@@ -287,7 +290,7 @@ func (g *GenerateKubeadmConfig) Execute(runtime connector.Runtime) error {
 	localConfig := filepath.Join(runtime.GetWorkDir(), "kubeadm-config.yaml")
 	if util.IsExist(localConfig) {
 		// todo: if it is necessary?
-		if err := runtime.GetRunner().Host.SudoScp(localConfig, "/etc/kubernetes/kubeadm-config.yaml"); err != nil {
+		if err := runtime.GetRunner().SudoScp(localConfig, "/etc/kubernetes/kubeadm-config.yaml"); err != nil {
 			return errors.Wrap(errors.WithStack(err), "scp local kubeadm config failed")
 		}
 	} else {
@@ -402,13 +405,13 @@ func (k *KubeadmInit) Execute(runtime connector.Runtime) error {
 	// we manage the creation of coredns ourselves
 	initCmd = initCmd + " --skip-phases=addon/coredns"
 
-	if _, err := runtime.GetRunner().Host.SudoCmd(initCmd, false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(initCmd, false, false); err != nil {
 		// kubeadm reset and then retry
 		resetCmd := "/usr/local/bin/kubeadm reset -f"
 		if k.KubeConf.Cluster.Kubernetes.ContainerRuntimeEndpoint != "" {
 			resetCmd = resetCmd + " --cri-socket " + k.KubeConf.Cluster.Kubernetes.ContainerRuntimeEndpoint
 		}
-		_, _ = runtime.GetRunner().Host.SudoCmd(resetCmd, false, true)
+		_, _ = runtime.GetRunner().SudoCmd(resetCmd, false, true)
 		return errors.Wrap(errors.WithStack(err), "init kubernetes cluster failed")
 	}
 	return nil
@@ -422,46 +425,46 @@ func (c *CopyKubeConfigForControlPlane) Execute(runtime connector.Runtime) error
 	createConfigDirCmd := "mkdir -p /root/.kube"
 	getKubeConfigCmd := "cp -f /etc/kubernetes/admin.conf /root/.kube/config"
 	cmd := strings.Join([]string{createConfigDirCmd, getKubeConfigCmd}, " && ")
-	if _, err := runtime.GetRunner().Host.SudoCmd(cmd, false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(cmd, false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "copy kube config failed")
 	}
 
 	userMkdir := "mkdir -p $HOME/.kube"
-	if _, err := runtime.GetRunner().Host.Cmd(userMkdir, false, false); err != nil {
+	if _, err := runtime.GetRunner().Cmd(userMkdir, false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "user mkdir $HOME/.kube failed")
 	}
 
 	userCopyKubeConfig := "cp -f /etc/kubernetes/admin.conf $HOME/.kube/config"
-	if _, err := runtime.GetRunner().Host.SudoCmd(userCopyKubeConfig, false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(userCopyKubeConfig, false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "user copy /etc/kubernetes/admin.conf to $HOME/.kube/config failed")
 	}
 
-	if _, err := runtime.GetRunner().Host.SudoCmd("chmod 0600 $HOME/.kube/config", false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd("chmod 0600 $HOME/.kube/config", false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "chmod $HOME/.kube/config failed")
 	}
 
-	// userId, err := runtime.GetRunner().Host.Cmd("echo $(id -u)", false, false)
+	// userId, err := runtime.GetRunner().Cmd("echo $(id -u)", false, false)
 	// if err != nil {
 	// 	return errors.Wrap(errors.WithStack(err), "get user id failed")
 	// }
 
-	// userGroupId, err := runtime.GetRunner().Host.Cmd("echo $(id -g)", false, false)
+	// userGroupId, err := runtime.GetRunner().Cmd("echo $(id -g)", false, false)
 	// if err != nil {
 	// 	return errors.Wrap(errors.WithStack(err), "get user group id failed")
 	// }
 
-	userId, err := runtime.GetRunner().Host.Cmd("echo $SUDO_UID", false, false)
+	userId, err := runtime.GetRunner().Cmd("echo $SUDO_UID", false, false)
 	if err != nil {
 		return errors.Wrap(errors.WithStack(err), "get user id failed")
 	}
 
-	userGroupId, err := runtime.GetRunner().Host.Cmd("echo $SUDO_GID", false, false)
+	userGroupId, err := runtime.GetRunner().Cmd("echo $SUDO_GID", false, false)
 	if err != nil {
 		return errors.Wrap(errors.WithStack(err), "get user group id failed")
 	}
 
 	chownKubeConfig := fmt.Sprintf("chown -R %s:%s $HOME/.kube", userId, userGroupId)
-	if _, err := runtime.GetRunner().Host.SudoCmd(chownKubeConfig, false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(chownKubeConfig, false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "chown user kube config failed")
 	}
 	return nil
@@ -472,12 +475,12 @@ type RemoveMasterTaint struct {
 }
 
 func (r *RemoveMasterTaint) Execute(runtime connector.Runtime) error {
-	if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf(
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf(
 		"/usr/local/bin/kubectl taint nodes %s node-role.kubernetes.io/master=:NoSchedule-",
 		runtime.RemoteHost().GetName()), false, true); err != nil {
 		logger.Warn(err.Error())
 	}
-	if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf(
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf(
 		"/usr/local/bin/kubectl taint nodes %s node-role.kubernetes.io/control-plane=:NoSchedule-",
 		runtime.RemoteHost().GetName()), false, true); err != nil {
 		logger.Warn(err.Error())
@@ -490,7 +493,7 @@ type AddWorkerLabel struct {
 }
 
 func (a *AddWorkerLabel) Execute(runtime connector.Runtime) error {
-	if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf(
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf(
 		"/usr/local/bin/kubectl label --overwrite node %s node-role.kubernetes.io/worker=",
 		runtime.RemoteHost().GetName()), false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "add worker label failed")
@@ -503,13 +506,13 @@ type JoinNode struct {
 }
 
 func (j *JoinNode) Execute(runtime connector.Runtime) error {
-	if _, err := runtime.GetRunner().Host.SudoCmd("/usr/local/bin/kubeadm join --config=/etc/kubernetes/kubeadm-config.yaml --ignore-preflight-errors=FileExisting-crictl,ImagePull",
+	if _, err := runtime.GetRunner().SudoCmd("/usr/local/bin/kubeadm join --config=/etc/kubernetes/kubeadm-config.yaml --ignore-preflight-errors=FileExisting-crictl,ImagePull",
 		true, false); err != nil {
 		resetCmd := "/usr/local/bin/kubeadm reset -f"
 		if j.KubeConf.Cluster.Kubernetes.ContainerRuntimeEndpoint != "" {
 			resetCmd = resetCmd + " --cri-socket " + j.KubeConf.Cluster.Kubernetes.ContainerRuntimeEndpoint
 		}
-		_, _ = runtime.GetRunner().Host.SudoCmd(resetCmd, true, false)
+		_, _ = runtime.GetRunner().SudoCmd(resetCmd, true, false)
 		return errors.Wrap(errors.WithStack(err), "join node failed")
 	}
 	return nil
@@ -524,51 +527,51 @@ func (s *SyncKubeConfigToWorker) Execute(runtime connector.Runtime) error {
 		cluster := v.(*KubernetesStatus)
 
 		createConfigDirCmd := "mkdir -p /root/.kube"
-		if _, err := runtime.GetRunner().Host.SudoCmd(createConfigDirCmd, false, false); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd(createConfigDirCmd, false, false); err != nil {
 			return errors.Wrap(errors.WithStack(err), "create .kube dir failed")
 		}
 
 		syncKubeConfigForRootCmd := fmt.Sprintf("echo '%s' > %s", cluster.KubeConfig, "/root/.kube/config")
-		if _, err := runtime.GetRunner().Host.SudoCmd(syncKubeConfigForRootCmd, false, false); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd(syncKubeConfigForRootCmd, false, false); err != nil {
 			return errors.Wrap(errors.WithStack(err), "sync kube config for root failed")
 		}
 
-		if _, err := runtime.GetRunner().Host.SudoCmd("chmod 0600 /root/.kube/config", false, false); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd("chmod 0600 /root/.kube/config", false, false); err != nil {
 			return errors.Wrap(errors.WithStack(err), "chmod $HOME/.kube/config failed")
 		}
 
 		userConfigDirCmd := "mkdir -p $HOME/.kube"
-		if _, err := runtime.GetRunner().Host.Cmd(userConfigDirCmd, false, false); err != nil {
+		if _, err := runtime.GetRunner().Cmd(userConfigDirCmd, false, false); err != nil {
 			return errors.Wrap(errors.WithStack(err), "user mkdir $HOME/.kube failed")
 		}
 
 		syncKubeConfigForUserCmd := fmt.Sprintf("echo '%s' > %s", cluster.KubeConfig, "$HOME/.kube/config")
-		if _, err := runtime.GetRunner().Host.Cmd(syncKubeConfigForUserCmd, false, false); err != nil {
+		if _, err := runtime.GetRunner().Cmd(syncKubeConfigForUserCmd, false, false); err != nil {
 			return errors.Wrap(errors.WithStack(err), "sync kube config for normal user failed")
 		}
 
-		// userId, err := runtime.GetRunner().Host.Cmd("echo $(id -u)", false, false)
+		// userId, err := runtime.GetRunner().Cmd("echo $(id -u)", false, false)
 		// if err != nil {
 		// 	return errors.Wrap(errors.WithStack(err), "get user id failed")
 		// }
 
-		// userGroupId, err := runtime.GetRunner().Host.Cmd("echo $(id -g)", false, false)
+		// userGroupId, err := runtime.GetRunner().Cmd("echo $(id -g)", false, false)
 		// if err != nil {
 		// 	return errors.Wrap(errors.WithStack(err), "get user group id failed")
 		// }
 
-		userId, err := runtime.GetRunner().Host.Cmd("echo $SUDO_UID", false, false)
+		userId, err := runtime.GetRunner().Cmd("echo $SUDO_UID", false, false)
 		if err != nil {
 			return errors.Wrap(errors.WithStack(err), "get user id failed")
 		}
 
-		userGroupId, err := runtime.GetRunner().Host.Cmd("echo $SUDO_GID", false, false)
+		userGroupId, err := runtime.GetRunner().Cmd("echo $SUDO_GID", false, false)
 		if err != nil {
 			return errors.Wrap(errors.WithStack(err), "get user group id failed")
 		}
 
 		chownKubeConfig := fmt.Sprintf("chown -R %s:%s -R $HOME/.kube", userId, userGroupId)
-		if _, err := runtime.GetRunner().Host.SudoCmd(chownKubeConfig, false, false); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd(chownKubeConfig, false, false); err != nil {
 			return errors.Wrap(errors.WithStack(err), "chown user kube config failed")
 		}
 	}
@@ -584,7 +587,7 @@ func (k *KubeadmReset) Execute(runtime connector.Runtime) error {
 	if k.KubeConf.Cluster.Kubernetes.ContainerRuntimeEndpoint != "" {
 		resetCmd = resetCmd + " --cri-socket " + k.KubeConf.Cluster.Kubernetes.ContainerRuntimeEndpoint
 	}
-	_, _ = runtime.GetRunner().Host.SudoCmd(resetCmd, false, true)
+	_, _ = runtime.GetRunner().SudoCmd(resetCmd, false, true)
 	return nil
 }
 
@@ -598,7 +601,7 @@ func (u *UmountKubelet) Execute(runtime connector.Runtime) error {
 	}
 
 	var cmd = fmt.Sprintf("cat /proc/self/mounts |grep 'kubelet' | sort -r")
-	var stdout, _ = runtime.GetRunner().Host.SudoCmd(cmd, false, false)
+	var stdout, _ = runtime.GetRunner().SudoCmd(cmd, false, false)
 	if stdout == "" {
 		return nil
 	}
@@ -621,10 +624,10 @@ func (u *UmountKubelet) Execute(runtime connector.Runtime) error {
 	logger.Infof("kubelet mounts %v", mounts)
 
 	for _, m := range mounts {
-		runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("umount %s", m), false, true)
+		runtime.GetRunner().SudoCmd(fmt.Sprintf("umount %s", m), false, true)
 	}
 
-	_, _ = runtime.GetRunner().Host.SudoCmd("systemctl stop kubepods.slice", false, true)
+	_, _ = runtime.GetRunner().SudoCmd("systemctl stop kubepods.slice", false, true)
 
 	return nil
 }
@@ -635,7 +638,7 @@ type FindNode struct {
 
 func (f *FindNode) Execute(runtime connector.Runtime) error {
 	var resArr []string
-	res, err := runtime.GetRunner().Host.Cmd(
+	res, err := runtime.GetRunner().Cmd(
 		"sudo -E /usr/local/bin/kubectl get nodes | grep -v NAME | grep -v 'master\\|control-plane' | awk '{print $1}'",
 		true, false)
 	if err != nil {
@@ -681,7 +684,7 @@ func (d *DrainNode) Execute(runtime connector.Runtime) error {
 	if !ok {
 		return errors.New("get dstNode failed by pipeline cache")
 	}
-	if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf(
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf(
 		"/usr/local/bin/kubectl drain %s --delete-emptydir-data --ignore-daemonsets --timeout=2m --force", nodeName),
 		true, false); err != nil {
 		return errors.Wrap(err, "drain the node failed")
@@ -698,7 +701,7 @@ func (k *KubectlDeleteNode) Execute(runtime connector.Runtime) error {
 	if !ok {
 		return errors.New("get dstNode failed by pipeline cache")
 	}
-	if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf(
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf(
 		"/usr/local/bin/kubectl delete node %s", nodeName),
 		true, false); err != nil {
 		return errors.Wrap(err, "delete the node failed")
@@ -804,14 +807,14 @@ func (u *UpgradeKubeMaster) Execute(runtime connector.Runtime) error {
 		return errors.Wrap(errors.WithStack(err), fmt.Sprintf("upgrade cluster using kubeadm failed: %s", host.GetName()))
 	}
 
-	if _, err := runtime.GetRunner().Host.SudoCmd("systemctl stop kubelet", false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd("systemctl stop kubelet", false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), fmt.Sprintf("stop kubelet failed: %s", host.GetName()))
 	}
 
 	if err := SetKubeletTasks(runtime, u.KubeAction); err != nil {
 		return errors.Wrap(errors.WithStack(err), fmt.Sprintf("set kubelet failed: %s", host.GetName()))
 	}
-	if _, err := runtime.GetRunner().Host.SudoCmd("systemctl daemon-reload && systemctl restart kubelet", true, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd("systemctl daemon-reload && systemctl restart kubelet", true, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), fmt.Sprintf("restart kubelet failed: %s", host.GetName()))
 	}
 
@@ -828,16 +831,16 @@ func (u *UpgradeKubeWorker) Execute(runtime connector.Runtime) error {
 
 	host := runtime.RemoteHost()
 
-	if _, err := runtime.GetRunner().Host.SudoCmd("/usr/local/bin/kubeadm upgrade node", true, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd("/usr/local/bin/kubeadm upgrade node", true, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), fmt.Sprintf("upgrade node using kubeadm failed: %s", host.GetName()))
 	}
-	if _, err := runtime.GetRunner().Host.SudoCmd("systemctl stop kubelet", true, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd("systemctl stop kubelet", true, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), fmt.Sprintf("stop kubelet failed: %s", host.GetName()))
 	}
 	if err := SetKubeletTasks(runtime, u.KubeAction); err != nil {
 		return errors.Wrap(errors.WithStack(err), fmt.Sprintf("set kubelet failed: %s", host.GetName()))
 	}
-	if _, err := runtime.GetRunner().Host.SudoCmd("systemctl daemon-reload && systemctl restart kubelet", true, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd("systemctl daemon-reload && systemctl restart kubelet", true, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), fmt.Sprintf("restart kubelet failed: %s", host.GetName()))
 	}
 	time.Sleep(10 * time.Second)
@@ -893,7 +896,7 @@ type KubeadmUpgrade struct {
 func (k *KubeadmUpgrade) Execute(runtime connector.Runtime) error {
 
 	host := runtime.RemoteHost()
-	if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf(
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf(
 		"timeout -k 600s 600s /usr/local/bin/kubeadm upgrade apply %s -y "+
 			"--ignore-preflight-errors=all "+
 			"--allow-experimental-upgrades "+
@@ -1075,7 +1078,7 @@ func (c *ConfigureKubernetes) Execute(runtime connector.Runtime) error {
 	kubeHost := host.(*kubekeyv1alpha2.KubeHost)
 	for k, v := range kubeHost.Labels {
 		labelCmd := fmt.Sprintf("/usr/local/bin/kubectl label --overwrite node %s %s=%s", host.GetName(), k, v)
-		_, err := runtime.GetRunner().Host.SudoCmd(labelCmd, true, false)
+		_, err := runtime.GetRunner().SudoCmd(labelCmd, true, false)
 		if err != nil {
 			return err
 		}
@@ -1101,7 +1104,7 @@ func (s *EtcdSecurityEnhancemenAction) Execute(runtime connector.Runtime) error 
 
 	ETCDcmds := []string{chmodEtcdCertsDirCmd, chmodEtcdCertsCmd, chmodEtcdDataDirCmd, chmodEtcdCmd, chownEtcdCertsDirCmd, chownEtcdCertsCmd, chownEtcdDataDirCmd, chownEtcdCmd}
 
-	if _, err := runtime.GetRunner().Host.SudoCmd(strings.Join(ETCDcmds, " && "), true, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(strings.Join(ETCDcmds, " && "), true, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "Updating permissions failed.")
 	}
 
@@ -1150,20 +1153,20 @@ func (k *MasterSecurityEnhancemenAction) Execute(runtime connector.Runtime) erro
 	chownCertsRenew := "chown root:root /etc/systemd/system/k8s-certs-renew*"
 
 	chmodMasterCmds := []string{chmodKubernetesConfigCmd, chmodKubernetesDirCmd, chmodKubenretesManifestsDirCmd, chmodKubenretesCertsDirCmd}
-	if _, err := runtime.GetRunner().Host.SudoCmd(strings.Join(chmodMasterCmds, " && "), true, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(strings.Join(chmodMasterCmds, " && "), true, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "Updating permissions failed.")
 	}
 	chownMasterCmds := []string{chownKubernetesConfigCmd, chownKubernetesDirCmd, chownKubenretesManifestsDirCmd, chownKubenretesCertsDirCmd}
-	if _, err := runtime.GetRunner().Host.SudoCmd(strings.Join(chownMasterCmds, " && "), true, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(strings.Join(chownMasterCmds, " && "), true, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "Updating permissions failed.")
 	}
 
 	chmodNodesCmds := []string{chmodBinDir, chmodKubeCmd, chmodHelmCmd, chmodCniDir, chmodCniConfigDir, chmodKubeletConfig, chmodCertsRenew}
-	if _, err := runtime.GetRunner().Host.SudoCmd(strings.Join(chmodNodesCmds, " && "), true, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(strings.Join(chmodNodesCmds, " && "), true, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "Updating permissions failed.")
 	}
 	chownNodesCmds := []string{chownBinDir, chownKubeCmd, chownHelmCmd, chownCniDir, chownCniConfigDir, chownKubeletConfig, chownCertsRenew}
-	if _, err := runtime.GetRunner().Host.SudoCmd(strings.Join(chownNodesCmds, " && "), true, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(strings.Join(chownNodesCmds, " && "), true, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "Updating permissions failed.")
 	}
 
@@ -1209,20 +1212,20 @@ func (n *NodesSecurityEnhancemenAction) Execute(runtime connector.Runtime) error
 	chownKubeletConfig := "chown root:root /var/lib/kubelet/config.yaml && chown root:root -R /etc/systemd/system/kubelet.service*"
 
 	chmodMasterCmds := []string{chmodKubernetesConfigCmd, chmodKubernetesDirCmd, chmodKubenretesManifestsDirCmd, chmodKubenretesCertsDirCmd}
-	if _, err := runtime.GetRunner().Host.SudoCmd(strings.Join(chmodMasterCmds, " && "), true, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(strings.Join(chmodMasterCmds, " && "), true, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "Updating permissions failed.")
 	}
 	chownMasterCmds := []string{chownKubernetesConfigCmd, chownKubernetesDirCmd, chownKubenretesManifestsDirCmd, chownKubenretesCertsDirCmd}
-	if _, err := runtime.GetRunner().Host.SudoCmd(strings.Join(chownMasterCmds, " && "), true, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(strings.Join(chownMasterCmds, " && "), true, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "Updating permissions failed.")
 	}
 
 	chmodNodesCmds := []string{chmodBinDir, chmodKubeCmd, chmodHelmCmd, chmodCniDir, chmodCniConfigDir, chmodKubeletConfig}
-	if _, err := runtime.GetRunner().Host.SudoCmd(strings.Join(chmodNodesCmds, " && "), true, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(strings.Join(chmodNodesCmds, " && "), true, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "Updating permissions failed.")
 	}
 	chownNodesCmds := []string{chownBinDir, chownKubeCmd, chownHelmCmd, chownCniDir, chownCniConfigDir, chownKubeletConfig}
-	if _, err := runtime.GetRunner().Host.SudoCmd(strings.Join(chownNodesCmds, " && "), true, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(strings.Join(chownNodesCmds, " && "), true, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "Updating permissions failed.")
 	}
 

--- a/pkg/kubernetes/templates/v1beta2/kubeadm_config.go
+++ b/pkg/kubernetes/templates/v1beta2/kubeadm_config.go
@@ -377,7 +377,7 @@ func GetKubeletCgroupDriver(runtime connector.Runtime, kubeConf *common.KubeConf
 		kubeletCgroupDriver = ""
 	}
 
-	checkResult, err := runtime.GetRunner().Host.SudoCmd(cmd, false, false)
+	checkResult, err := runtime.GetRunner().SudoCmd(cmd, false, false)
 	if err != nil {
 		return "", errors.Wrap(errors.WithStack(err), "Failed to get container runtime cgroup driver.")
 	}

--- a/pkg/kubesphere/plugins/kscore.go
+++ b/pkg/kubesphere/plugins/kscore.go
@@ -29,7 +29,7 @@ func (t *CreateKsCore) Execute(runtime connector.Runtime) error {
 
 	var cmd = fmt.Sprintf("%s get pod -n %s -l 'app=redis,tier=database,version=redis-4.0' -o jsonpath='{.items[0].status.phase}'", kubectlpath,
 		common.NamespaceKubesphereSystem)
-	rphase, err := runtime.GetRunner().Host.SudoCmd(cmd, false, false)
+	rphase, err := runtime.GetRunner().SudoCmd(cmd, false, false)
 	if rphase != "Running" {
 		return fmt.Errorf("Redis State %s", rphase)
 	}

--- a/pkg/kubesphere/plugins/kscore_config.go
+++ b/pkg/kubesphere/plugins/kscore_config.go
@@ -166,7 +166,7 @@ func (t *CreateKsRole) Execute(runtime connector.Runtime) error {
 	}
 
 	cmd := fmt.Sprintf("%s apply -f %s", kubectlpath, f)
-	_, err := runtime.GetRunner().Host.SudoCmd(cmd, false, true)
+	_, err := runtime.GetRunner().SudoCmd(cmd, false, true)
 	if err != nil {
 		return errors.Wrap(errors.WithStack(err), "create ks role failed")
 	}
@@ -183,10 +183,10 @@ func (t *PatchKsCoreStatus) Execute(runtime connector.Runtime) error {
 		kubectlpath = path.Join(common.BinDir, common.CommandKubectl)
 	}
 
-	var jsonPath = fmt.Sprintf(`{\"status\": {\"core\": {\"status\": \"enabled\", \"enabledTime\": \"%s\"}}}`, time.Now().Format("2006-01-02T15:04:05Z"))
+	var jsonPath = fmt.Sprintf(`{"status": {"core": {"status": "enabled", "enabledTime": "%s"}}}`, time.Now().Format("2006-01-02T15:04:05Z"))
 	var cmd = fmt.Sprintf("%s patch cc ks-installer --type merge -p '%s' -n %s", kubectlpath, jsonPath, common.NamespaceKubesphereSystem)
 
-	_, err := runtime.GetRunner().Host.SudoCmd(cmd, false, true)
+	_, err := runtime.GetRunner().SudoCmd(cmd, false, true)
 	if err != nil {
 		return errors.Wrap(errors.WithStack(err), "patch ks-core status failed")
 	}
@@ -267,7 +267,7 @@ func (t *CreateKsCoreConfigManifests) Execute(runtime connector.Runtime) error {
 			return err
 		}
 		if !info.IsDir() {
-			_, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("%s apply -f %s", kubectlpath, path), false, true)
+			_, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("%s apply -f %s", kubectlpath, path), false, true)
 			if err != nil {
 				logger.Errorf("failed to apply %s: %v", path, err)
 				return err
@@ -308,7 +308,7 @@ func (t *PacthKsCore) Execute(runtime connector.Runtime) error {
 				kubectlpath, item["ns"], item["kind"], item["resource"], common.NamespaceKubesphereSystem,
 				kubectlpath, item["ns"], item["kind"], item["resource"])
 
-			if _, err := runtime.GetRunner().Host.SudoCmd(cmd, false, true); err != nil {
+			if _, err := runtime.GetRunner().SudoCmd(cmd, false, true); err != nil {
 				return errors.Wrap(errors.WithStack(err), "patch ks-core crd")
 			}
 		}
@@ -332,7 +332,7 @@ func (t *CheckKsCoreExist) Execute(runtime connector.Runtime) error {
 	cmd = fmt.Sprintf("%s -n %s get secrets --field-selector=type=helm.sh/release.v1 | grep ks-core |wc -l",
 		kubectlpath,
 		common.NamespaceKubesphereSystem)
-	stdout, _ := runtime.GetRunner().Host.SudoCmd(cmd, false, false)
+	stdout, _ := runtime.GetRunner().SudoCmd(cmd, false, false)
 
 	secretNum, err := strconv.ParseInt(stdout, 10, 64)
 	if err != nil {
@@ -340,7 +340,7 @@ func (t *CheckKsCoreExist) Execute(runtime connector.Runtime) error {
 	}
 
 	cmd = fmt.Sprintf("%s get crd users.iam.kubesphere.io | grep 'users.iam.kubesphere.io' |wc -l", kubectlpath)
-	stdout, _ = runtime.GetRunner().Host.SudoCmd(cmd, false, false)
+	stdout, _ = runtime.GetRunner().SudoCmd(cmd, false, false)
 
 	usersCrdNum, err := strconv.ParseInt(stdout, 10, 64)
 	if err != nil {

--- a/pkg/kubesphere/plugins/monitor_dashboard.go
+++ b/pkg/kubesphere/plugins/monitor_dashboard.go
@@ -24,7 +24,7 @@ func (t *InstallMonitorDashboardCrd) Execute(runtime connector.Runtime) error {
 
 	var p = path.Join(runtime.GetInstallerDir(), cc.BuildFilesCacheDir, cc.BuildDir, "ks-monitor", "monitoring-dashboard")
 	var cmd = fmt.Sprintf("%s apply -f %s", kubectlpath, p)
-	if _, err := runtime.GetRunner().Host.SudoCmd(cmd, false, true); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(cmd, false, true); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/kubesphere/plugins/prepares.go
+++ b/pkg/kubesphere/plugins/prepares.go
@@ -34,7 +34,7 @@ type IsCloudInstance struct {
 }
 
 func (p *IsCloudInstance) PreCheck(runtime connector.Runtime) (bool, error) {
-	if runtime.GetRunner().Host.GetOs() == common.Darwin {
+	if runtime.RemoteHost().GetOs() == common.Darwin {
 		return true, nil
 	}
 
@@ -56,7 +56,7 @@ func (p *CheckStorageClass) PreCheck(runtime connector.Runtime) (bool, error) {
 	}
 
 	var cmd = fmt.Sprintf("%s get sc | awk '{if(NR>1){print $1}}'", kubectlpath)
-	stdout, err := runtime.GetRunner().Host.SudoCmd(cmd, false, true)
+	stdout, err := runtime.GetRunner().SudoCmd(cmd, false, true)
 	if err != nil {
 		return false, errors.Wrap(errors.WithStack(err), "get storageclass failed")
 	}
@@ -65,7 +65,7 @@ func (p *CheckStorageClass) PreCheck(runtime connector.Runtime) (bool, error) {
 	}
 
 	cmd = fmt.Sprintf("%s get sc --no-headers", kubectlpath)
-	stdout, err = runtime.GetRunner().Host.SudoCmd(cmd, false, true)
+	stdout, err = runtime.GetRunner().SudoCmd(cmd, false, true)
 	if err != nil {
 		return false, errors.Wrap(errors.WithStack(err), "get storageclass failed")
 	}

--- a/pkg/kubesphere/plugins/prometheus.go
+++ b/pkg/kubesphere/plugins/prometheus.go
@@ -43,7 +43,7 @@ func (t *CreatePrometheusComponent) Execute(runtime connector.Runtime) error {
 	}
 
 	var cmd = fmt.Sprintf("%s apply -f %s %s %s", kubectlpath, f, t.Force, t.ServerSide)
-	if _, err := runtime.GetRunner().Host.SudoCmd(cmd, false, true); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(cmd, false, true); err != nil {
 		logger.Errorf("create crd %s failed: %v", f, err)
 		return err
 	}
@@ -89,7 +89,7 @@ func (t *CreateOperator) Execute(runtime connector.Runtime) error {
 
 	for _, crd := range crds {
 		var cmd = fmt.Sprintf("%s apply -f %s --force-conflicts --server-side", kubectlpath, crd)
-		if _, err := runtime.GetRunner().Host.SudoCmd(cmd, false, true); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd(cmd, false, true); err != nil {
 			logger.Errorf("create crd %s failed: %v", crd, err)
 			return err
 		}
@@ -97,7 +97,7 @@ func (t *CreateOperator) Execute(runtime connector.Runtime) error {
 
 	for _, res := range ress {
 		var cmd = fmt.Sprintf("%s apply -f %s --force-conflicts --server-side", kubectlpath, res)
-		if _, err := runtime.GetRunner().Host.SudoCmd(cmd, false, true); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd(cmd, false, true); err != nil {
 			logger.Errorf("create crd %s failed: %v", res, err)
 			return err
 		}

--- a/pkg/kubesphere/plugins/redis.go
+++ b/pkg/kubesphere/plugins/redis.go
@@ -34,7 +34,7 @@ func (t *CreateRedisSecret) Execute(runtime connector.Runtime) error {
 		return fmt.Errorf("get redis password from module cache failed")
 	}
 
-	if stdout, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("%s -n %s create secret generic redis-secret --from-literal=auth=%s", kubectlpath, common.NamespaceKubesphereSystem, redisPwd), false, true); err != nil {
+	if stdout, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("%s -n %s create secret generic redis-secret --from-literal=auth=%s", kubectlpath, common.NamespaceKubesphereSystem, redisPwd), false, true); err != nil {
 		if err != nil && !strings.Contains(stdout, "already exists") {
 			return errors.Wrap(errors.WithStack(err), "create redis secret failed")
 		}
@@ -53,7 +53,7 @@ func (t *BackupRedisManifests) Execute(runtime connector.Runtime) error {
 		return fmt.Errorf("kubectl not found")
 	}
 
-	rver, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("%s get pod -n %s -l app=%s,tier=database,version=%s-4.0 | wc -l",
+	rver, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("%s get pod -n %s -l app=%s,tier=database,version=%s-4.0 | wc -l",
 		kubectlpath, common.NamespaceKubesphereSystem, common.ChartNameRedis, common.ChartNameRedis), false, false)
 
 	if err != nil || strings.Contains(rver, "No resources found") {
@@ -70,7 +70,7 @@ func (t *BackupRedisManifests) Execute(runtime connector.Runtime) error {
 			kubectlpath,
 			common.NamespaceKubesphereSystem, common.ChartNameRedis)
 
-		if _, err := runtime.GetRunner().Host.SudoCmd(cmd, false, true); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd(cmd, false, true); err != nil {
 			logger.Errorf("failed to backup %s svc: %v", common.ChartNameRedis, err)
 			return errors.Wrap(errors.WithStack(err), "backup redis svc failed")
 		}
@@ -125,11 +125,11 @@ func (t *PatchRedisStatus) Execute(runtime connector.Runtime) error {
 		return fmt.Errorf("kubectl not found")
 	}
 
-	var jsonPatch = fmt.Sprintf(`{\"status\": {\"redis\": {\"status\": \"enabled\", \"enabledTime\": \"%s\"}}}`,
+	var jsonPatch = fmt.Sprintf(`{"status": {"redis": {"status": "enabled", "enabledTime": "%s"}}}`,
 		time.Now().Format("2006-01-02T15:04:05Z"))
 	var cmd = fmt.Sprintf("%s patch cc ks-installer --type merge -p '%s' -n %s", kubectlpath, jsonPatch, common.NamespaceKubesphereSystem)
 
-	_, err = runtime.GetRunner().Host.SudoCmd(cmd, false, true)
+	_, err = runtime.GetRunner().SudoCmd(cmd, false, true)
 	if err != nil {
 		return errors.Wrap(errors.WithStack(err), "patch redis status failed")
 	}

--- a/pkg/kubesphere/plugins/snapshotcontroller.go
+++ b/pkg/kubesphere/plugins/snapshotcontroller.go
@@ -31,7 +31,7 @@ func (t *DeploySnapshotController) Execute(runtime connector.Runtime) error {
 	var buildFilesDir = path.Join(runtime.GetInstallerDir(), cc.BuildFilesCacheDir, cc.BuildDir)
 	var scrd = path.Join(buildFilesDir, "snapshot-controller", "crds", "snapshot.storage.k8s.io_volumesnapshot.yaml")
 	var cmd = fmt.Sprintf("%s apply -f %s --force", kubectlpath, scrd)
-	if _, err := runtime.GetRunner().Host.SudoCmd(cmd, false, true); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(cmd, false, true); err != nil {
 		logger.Errorf("Install snapshot controller failed: %v", err)
 	}
 

--- a/pkg/kubesphere/plugins/tasks.go
+++ b/pkg/kubesphere/plugins/tasks.go
@@ -32,7 +32,7 @@ func (t *CheckNodeState) Execute(runtime connector.Runtime) error {
 		kubectlpath = path.Join(common.BinDir, common.CommandKubectl)
 	}
 	var cmd = fmt.Sprintf("%s get node --no-headers", kubectlpath)
-	stdout, err := runtime.GetRunner().Host.SudoCmd(cmd, false, false)
+	stdout, err := runtime.GetRunner().SudoCmd(cmd, false, false)
 
 	if err != nil || stdout == "" {
 		return fmt.Errorf("Node Pending")
@@ -66,14 +66,14 @@ func (t *InitNamespace) Execute(runtime connector.Runtime) error {
 	}
 
 	for _, ns := range []string{common.NamespaceKubesphereControlsSystem, common.NamespaceKubesphereMonitoringFederated} {
-		if stdout, err := runtime.GetRunner().Host.CmdExt(fmt.Sprintf("%s create ns %s", kubectlpath, ns), false, true); err != nil {
+		if stdout, err := runtime.GetRunner().Cmd(fmt.Sprintf("%s create ns %s", kubectlpath, ns), false, true); err != nil {
 			if !strings.Contains(stdout, "already exists") {
 				logger.Errorf("create ns %s failed: %v", ns, err)
 				return errors.Wrap(errors.WithStack(err), fmt.Sprintf("create namespace %s failed: %v", ns, err))
 			}
 		}
 	}
-	// _, err := runtime.GetRunner().Host.SudoCmd(
+	// _, err := runtime.GetRunner().SudoCmd(
 	// 	fmt.Sprintf(`cat <<EOF | /usr/local/bin/kubectl apply -f -
 	// apiVersion: v1
 	// kind: Namespace
@@ -104,12 +104,12 @@ func (t *InitNamespace) Execute(runtime connector.Runtime) error {
 	}
 
 	for _, ns := range allNs {
-		if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("%s label ns %s kubesphere.io/workspace=system-workspace --overwrite", kubectlpath, ns), false, true); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("%s label ns %s kubesphere.io/workspace=system-workspace --overwrite", kubectlpath, ns), false, true); err != nil {
 			logger.Errorf("label ns %s kubesphere.io/workspace=system-workspace failed: %v", ns, err)
 			return errors.Wrap(errors.WithStack(err), fmt.Sprintf("label namespace %s kubesphere.io/workspace=system-workspace failed: %v", ns, err))
 		}
 
-		if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("%s label ns %s kubesphere.io/namespace=%s --overwrite", kubectlpath, ns, ns), false, true); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("%s label ns %s kubesphere.io/namespace=%s --overwrite", kubectlpath, ns, ns), false, true); err != nil {
 			logger.Errorf("label ns %s kubesphere.io/namespace=%s failed: %v", ns, ns, err)
 			return errors.Wrap(errors.WithStack(err), fmt.Sprintf("label namespace %s kubesphere.io/namespace=%s failed: %v", ns, ns, err))
 		}

--- a/pkg/kubesphere/plugins/token.go
+++ b/pkg/kubesphere/plugins/token.go
@@ -37,15 +37,15 @@ func (t *GenerateKubeSphereToken) Execute(runtime connector.Runtime) error {
 	}
 
 	var cmd = fmt.Sprintf("%s get secrets -n %s --no-headers", kubectlpath, common.NamespaceKubesphereSystem)
-	stdout, _ := runtime.GetRunner().Host.SudoCmd(cmd, false, false)
+	stdout, _ := runtime.GetRunner().SudoCmd(cmd, false, false)
 	if strings.Contains(stdout, "kubesphere-secret") {
 		cmd = fmt.Sprintf("%s delete secrets -n %s kubesphere-secret", kubectlpath, common.NamespaceKubesphereSystem)
-		runtime.GetRunner().Host.SudoCmd(cmd, false, true)
+		runtime.GetRunner().SudoCmd(cmd, false, true)
 	}
 
 	cmd = fmt.Sprintf("%s create secret generic kubesphere-secret --from-literal=token=%s --from-literal=secret=%s -n %s", kubectlpath,
 		token, random, common.NamespaceKubesphereSystem)
-	if _, err := runtime.GetRunner().Host.SudoCmd(cmd, false, true); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(cmd, false, true); err != nil {
 		return errors.Wrap(errors.WithStack(err), "create kubesphere token failed")
 	}
 

--- a/pkg/phase/cluster/add_node.go
+++ b/pkg/phase/cluster/add_node.go
@@ -1,0 +1,84 @@
+package cluster
+
+import (
+	"bytetrade.io/web3os/installer/pkg/bootstrap/os"
+	"bytetrade.io/web3os/installer/pkg/common"
+	"bytetrade.io/web3os/installer/pkg/core/logger"
+	"bytetrade.io/web3os/installer/pkg/core/module"
+	"bytetrade.io/web3os/installer/pkg/core/pipeline"
+	"bytetrade.io/web3os/installer/pkg/k3s"
+	"bytetrade.io/web3os/installer/pkg/kubernetes"
+	"bytetrade.io/web3os/installer/pkg/manifest"
+	"bytetrade.io/web3os/installer/pkg/storage"
+	"bytetrade.io/web3os/installer/pkg/terminus"
+)
+
+func AddNodePhase(runtime *common.KubeRuntime) *pipeline.Pipeline {
+	var err error
+	var manifestMap manifest.InstallationManifest
+	manifestMap, err = manifest.ReadAll(runtime.Arg.Manifest)
+	if err != nil {
+		logger.Fatal(err)
+	}
+
+	var m []module.Module
+	m = append(m,
+		&terminus.GetMasterInfoModule{},
+		&terminus.CheckPreparedModule{Force: true},
+		&storage.InstallJuiceFsModule{
+			ManifestModule: manifest.ManifestModule{
+				Manifest: manifestMap,
+				BaseDir:  runtime.GetBaseDir(),
+			},
+		},
+		&AddNodeModule{
+			ManifestModule: manifest.ManifestModule{
+				Manifest: manifestMap,
+				BaseDir:  runtime.GetBaseDir(),
+			},
+		},
+	)
+
+	m = append(m, &terminus.SaveMasterHostConfigModule{}, &terminus.InstalledModule{})
+
+	return &pipeline.Pipeline{
+		Name:    "Add Worker Node To The Cluster",
+		Modules: m,
+		Runtime: runtime,
+	}
+}
+
+type AddNodeModule struct {
+	common.KubeModule
+	manifest.ManifestModule
+	underlyingModules []module.TaskModule
+}
+
+func (m *AddNodeModule) Init() {
+	m.Name = "JoinKubernetesCluster"
+	if m.KubeConf.Arg.Kubetype == common.K8s {
+		m.underlyingModules = []module.TaskModule{
+			&kubernetes.StatusModule{},
+			&os.ConfigureOSModule{},
+			&kubernetes.InstallKubeBinariesModule{
+				ManifestModule: m.ManifestModule,
+			},
+			&kubernetes.JoinNodesModule{},
+		}
+	} else {
+		m.underlyingModules = []module.TaskModule{
+			&k3s.StatusModule{},
+			&os.ConfigureOSModule{},
+			&k3s.InstallKubeBinariesModule{
+				ManifestModule: m.ManifestModule,
+			},
+			&k3s.JoinNodesModule{},
+		}
+	}
+	for _, underlyingModule := range m.underlyingModules {
+		underlyingModule.Default(m.Runtime, m.PipelineCache, m.ModuleCache)
+		underlyingModule.AutoAssert()
+		underlyingModule.Init()
+		m.Tasks = append(m.Tasks, underlyingModule.GetTasks()...)
+	}
+}

--- a/pkg/phase/cluster/create_cluster.go
+++ b/pkg/phase/cluster/create_cluster.go
@@ -68,8 +68,8 @@ func NewK3sCreateClusterPhase(runtime *common.KubeRuntime, manifestMap manifest.
 	}
 
 	m := []module.Module{
-		&os.ConfigureOSModule{},
 		&k3s.StatusModule{},
+		&os.ConfigureOSModule{},
 		&etcd.PreCheckModule{Skip: runtime.Cluster.Etcd.Type != kubekeyapiv1alpha2.KubeKey},
 		&etcd.CertsModule{},
 		&etcd.InstallETCDBinaryModule{
@@ -130,8 +130,8 @@ func NewCreateClusterPhase(runtime *common.KubeRuntime, manifestMap manifest.Ins
 	m := []module.Module{
 		&precheck.NodePreCheckModule{},
 		&confirm.InstallConfirmModule{Skip: runtime.Arg.SkipConfirmCheck},
-		&os.ConfigureOSModule{},
 		&kubernetes.StatusModule{},
+		&os.ConfigureOSModule{},
 		&etcd.PreCheckModule{Skip: runtime.Cluster.Etcd.Type != kubekeyapiv1alpha2.KubeKey},
 		&etcd.CertsModule{},
 		&etcd.InstallETCDBinaryModule{

--- a/pkg/pipelines/add_node.go
+++ b/pkg/pipelines/add_node.go
@@ -1,0 +1,45 @@
+package pipelines
+
+import (
+	"bytetrade.io/web3os/installer/cmd/ctl/options"
+	"bytetrade.io/web3os/installer/pkg/common"
+	"bytetrade.io/web3os/installer/pkg/phase/cluster"
+	"fmt"
+	"github.com/pkg/errors"
+	"os"
+	"path"
+)
+
+func AddNodePipeline(opts *options.AddNodeOptions) error {
+	arg := common.NewArgument()
+	if !arg.SystemInfo.IsLinux() {
+		fmt.Println("error: Only Linux nodes can be added to an Olares cluster!")
+		os.Exit(1)
+	}
+	arg.SetBaseDir(opts.BaseDir)
+	if opts.Version == "" {
+		return errors.New("Olares version must be specified")
+	}
+	arg.SetTerminusVersion(opts.Version)
+	if err := arg.LoadMasterHostConfigIfAny(); err != nil {
+		return errors.Wrap(err, "failed to load master host config")
+	}
+	arg.SetMasterHostOverride(opts.MasterHostConfig)
+	if err := arg.MasterHostConfig.Validate(); err != nil {
+		return fmt.Errorf("invalid master host config: %w", err)
+	}
+	arg.SetConsoleLog("addnode.log", true)
+	runtime, err := common.NewKubeRuntime(common.AllInOne, *arg)
+	if err != nil {
+		return fmt.Errorf("error creating runtime: %v", err)
+	}
+
+	manifest := path.Join(runtime.GetInstallerDir(), "installation.manifest")
+	runtime.Arg.SetManifest(manifest)
+
+	var p = cluster.AddNodePhase(runtime)
+	if err := p.Start(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/pipelines/changeip.go
+++ b/pkg/pipelines/changeip.go
@@ -4,8 +4,12 @@ import (
 	"bytetrade.io/web3os/installer/cmd/ctl/options"
 	"bytetrade.io/web3os/installer/pkg/common"
 	"bytetrade.io/web3os/installer/pkg/core/logger"
+	"bytetrade.io/web3os/installer/pkg/core/util"
 	"bytetrade.io/web3os/installer/pkg/phase"
 	"bytetrade.io/web3os/installer/pkg/phase/cluster"
+	"fmt"
+	"github.com/pkg/errors"
+	"net"
 )
 
 func ChangeIPPipeline(opt *options.ChangeIPOptions) error {
@@ -22,6 +26,22 @@ func ChangeIPPipeline(opt *options.ChangeIPOptions) error {
 	arg.SetKubeVersion(kubeType)
 	arg.SetMinikubeProfile(opt.MinikubeProfile)
 	arg.SetWSLDistribution(opt.WSLDistribution)
+	if err := arg.LoadMasterHostConfigIfAny(); err != nil {
+		return errors.Wrap(err, "failed to load master host config")
+	}
+	if opt.NewMasterHost != "" {
+		if ip := net.ParseIP(opt.NewMasterHost); !util.IsValidIPv4Addr(ip) {
+			return fmt.Errorf("master host %s is not a valid IPv4 address", opt.NewMasterHost)
+		} else {
+			arg.MasterHost = opt.NewMasterHost
+		}
+	}
+	//only run validation if it's a worker node with master host config set
+	if arg.MasterHost != "" {
+		if err := arg.MasterHostConfig.Validate(); err != nil {
+			return fmt.Errorf("invalid master host config: %w", err)
+		}
+	}
 
 	runtime, err := common.NewKubeRuntime(common.AllInOne, *arg)
 	if err != nil {

--- a/pkg/pipelines/masterinfo.go
+++ b/pkg/pipelines/masterinfo.go
@@ -1,0 +1,45 @@
+package pipelines
+
+import (
+	"bytetrade.io/web3os/installer/cmd/ctl/options"
+	"bytetrade.io/web3os/installer/pkg/common"
+	"bytetrade.io/web3os/installer/pkg/core/module"
+	"bytetrade.io/web3os/installer/pkg/core/pipeline"
+	"bytetrade.io/web3os/installer/pkg/terminus"
+	"fmt"
+	"github.com/pkg/errors"
+	"os"
+)
+
+func MasterInfoPipeline(opts *options.MasterInfoOptions) error {
+	arg := common.NewArgument()
+	if !arg.SystemInfo.IsLinux() {
+		fmt.Println("error: Only Linux nodes can be added to an Olares cluster!")
+		os.Exit(1)
+	}
+	arg.SetBaseDir(opts.BaseDir)
+
+	if err := arg.LoadMasterHostConfigIfAny(); err != nil {
+		return errors.Wrap(err, "failed to load master host config")
+	}
+	arg.SetMasterHostOverride(opts.MasterHostConfig)
+	if err := arg.MasterHostConfig.Validate(); err != nil {
+		return fmt.Errorf("invalid master host config: %w", err)
+	}
+	arg.SetConsoleLog("masterinfo.log", true)
+
+	runtime, err := common.NewKubeRuntime(common.AllInOne, *arg)
+	if err != nil {
+		return fmt.Errorf("error creating runtime: %v", err)
+	}
+
+	p := &pipeline.Pipeline{
+		Name:    "Get Master Info",
+		Modules: []module.Module{&terminus.GetMasterInfoModule{Print: true}},
+		Runtime: runtime,
+	}
+	if err := p.Start(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/plugins/dns/prepares.go
+++ b/pkg/plugins/dns/prepares.go
@@ -29,7 +29,7 @@ type CoreDNSExist struct {
 }
 
 func (c *CoreDNSExist) PreCheck(runtime connector.Runtime) (bool, error) {
-	_, err := runtime.GetRunner().Host.SudoCmd("/usr/local/bin/kubectl get svc -n kube-system coredns", false, false)
+	_, err := runtime.GetRunner().SudoCmd("/usr/local/bin/kubectl get svc -n kube-system coredns", false, false)
 	if err != nil {
 		if strings.Contains(err.Error(), "NotFound") {
 			return c.Not, nil
@@ -55,7 +55,7 @@ type NodeLocalDNSConfigMapNotExist struct {
 }
 
 func (n *NodeLocalDNSConfigMapNotExist) PreCheck(runtime connector.Runtime) (bool, error) {
-	if _, err := runtime.GetRunner().Host.SudoCmd("/usr/local/bin/kubectl get cm -n kube-system nodelocaldns", false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd("/usr/local/bin/kubectl get cm -n kube-system nodelocaldns", false, false); err != nil {
 		if strings.Contains(err.Error(), "NotFound") {
 			return true, nil
 		}

--- a/pkg/plugins/dns/tasks.go
+++ b/pkg/plugins/dns/tasks.go
@@ -44,10 +44,10 @@ func (s *SetProxyNameServer) Execute(runtime connector.Runtime) error {
 			return nil
 		}
 
-		if _, err := runtime.GetRunner().Host.SudoCmd("cat /etc/resolv.conf > /etc/resolv.conf.bak", false, false); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd("cat /etc/resolv.conf > /etc/resolv.conf.bak", false, false); err != nil {
 			logger.Errorf("backup /etc/resolv.conf failed: %v", err)
 		}
-		if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("echo nameserver %s > /etc/resolv.conf", addr), false, true); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("echo nameserver %s > /etc/resolv.conf", addr), false, true); err != nil {
 			logger.Errorf("set nameserver %s failed: %v", addr, err)
 		}
 	}
@@ -59,7 +59,7 @@ type ApplyCoreDNS struct {
 }
 
 func (o *ApplyCoreDNS) Execute(runtime connector.Runtime) error {
-	if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("/usr/local/bin/kubectl apply -f %s", filepath.Join(common.KubeConfigDir, templates.CorednsService.Name())), false, true); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("/usr/local/bin/kubectl apply -f %s", filepath.Join(common.KubeConfigDir, templates.CorednsService.Name())), false, true); err != nil {
 		return errors.Wrap(errors.WithStack(err), "apply coredns service failed")
 	}
 	return nil
@@ -70,7 +70,7 @@ type DeployNodeLocalDNS struct {
 }
 
 func (d *DeployNodeLocalDNS) Execute(runtime connector.Runtime) error {
-	if _, err := runtime.GetRunner().Host.SudoCmd("/usr/local/bin/kubectl apply -f /etc/kubernetes/nodelocaldns.yaml", false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd("/usr/local/bin/kubectl apply -f /etc/kubernetes/nodelocaldns.yaml", false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "deploy nodelocaldns failed")
 	}
 	return nil
@@ -81,7 +81,7 @@ type GenerateNodeLocalDNSConfigMap struct {
 }
 
 func (g *GenerateNodeLocalDNSConfigMap) Execute(runtime connector.Runtime) error {
-	clusterIP, err := runtime.GetRunner().Host.SudoCmd("/usr/local/bin/kubectl get svc -n kube-system coredns -o jsonpath='{.spec.clusterIP}'", false, false)
+	clusterIP, err := runtime.GetRunner().SudoCmd("/usr/local/bin/kubectl get svc -n kube-system coredns -o jsonpath='{.spec.clusterIP}'", false, false)
 	if err != nil {
 		return errors.Wrap(errors.WithStack(err), "get clusterIP failed")
 	}
@@ -111,7 +111,7 @@ type ApplyNodeLocalDNSConfigMap struct {
 }
 
 func (a *ApplyNodeLocalDNSConfigMap) Execute(runtime connector.Runtime) error {
-	if _, err := runtime.GetRunner().Host.SudoCmd("/usr/local/bin/kubectl apply -f /etc/kubernetes/nodelocaldnsConfigmap.yaml", false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd("/usr/local/bin/kubectl apply -f /etc/kubernetes/nodelocaldnsConfigmap.yaml", false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "apply nodelocaldns configmap failed")
 	}
 	return nil

--- a/pkg/plugins/kata.go
+++ b/pkg/plugins/kata.go
@@ -199,7 +199,7 @@ type ApplyKataDeployManifests struct {
 }
 
 func (a *ApplyKataDeployManifests) Execute(runtime connector.Runtime) error {
-	if _, err := runtime.GetRunner().Host.SudoCmd("/usr/local/bin/kubectl apply -f /etc/kubernetes/addons/kata-deploy.yaml", true, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd("/usr/local/bin/kubectl apply -f /etc/kubernetes/addons/kata-deploy.yaml", true, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "apply kata-deploy manifests failed")
 	}
 	return nil

--- a/pkg/plugins/network/tasks.go
+++ b/pkg/plugins/network/tasks.go
@@ -66,10 +66,10 @@ type SyncCiliumChart struct {
 func (s *SyncCiliumChart) Execute(runtime connector.Runtime) error {
 	src := filepath.Join(runtime.GetWorkDir(), "cilium.tgz")
 	dst := filepath.Join(common.TmpDir, "cilium.tgz")
-	if err := runtime.GetRunner().Host.Scp(src, dst); err != nil {
+	if err := runtime.GetRunner().Scp(src, dst); err != nil {
 		return errors.Wrap(errors.WithStack(err), fmt.Sprintf("sync cilium chart failed"))
 	}
-	if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("mv %s/cilium.tgz /etc/kubernetes", common.TmpDir), true, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("mv %s/cilium.tgz /etc/kubernetes", common.TmpDir), true, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "sync cilium chart failed")
 	}
 	return nil
@@ -93,7 +93,7 @@ func (d *DeployCilium) Execute(runtime connector.Runtime) error {
 		cmd = fmt.Sprintf("%s --set kubeProxyReplacement=strict --set k8sServiceHost=%s --set k8sServicePort=%d", cmd, d.KubeConf.Cluster.ControlPlaneEndpoint.Address, d.KubeConf.Cluster.ControlPlaneEndpoint.Port)
 	}
 
-	if _, err := runtime.GetRunner().Host.SudoCmd(cmd, true, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(cmd, true, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "deploy cilium failed")
 	}
 	return nil
@@ -104,7 +104,7 @@ type DeployNetworkPlugin struct {
 }
 
 func (d *DeployNetworkPlugin) Execute(runtime connector.Runtime) error {
-	if _, err := runtime.GetRunner().Host.SudoCmd(
+	if _, err := runtime.GetRunner().SudoCmd(
 		"/usr/local/bin/kubectl apply -f /etc/kubernetes/network-plugin.yaml --force", false, true); err != nil {
 		return errors.Wrap(errors.WithStack(err), "deploy network plugin failed")
 	}
@@ -116,15 +116,15 @@ type DeployKubeovnPlugin struct {
 }
 
 func (d *DeployKubeovnPlugin) Execute(runtime connector.Runtime) error {
-	if _, err := runtime.GetRunner().Host.SudoCmd(
+	if _, err := runtime.GetRunner().SudoCmd(
 		"/usr/local/bin/kubectl apply -f /etc/kubernetes/kube-ovn-crd.yaml --force", true, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "deploy kube-ovn-crd.yaml failed")
 	}
-	if _, err := runtime.GetRunner().Host.SudoCmd(
+	if _, err := runtime.GetRunner().SudoCmd(
 		"/usr/local/bin/kubectl apply -f /etc/kubernetes/ovn.yaml --force", true, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "deploy ovn.yaml failed")
 	}
-	if _, err := runtime.GetRunner().Host.SudoCmd(
+	if _, err := runtime.GetRunner().SudoCmd(
 		"/usr/local/bin/kubectl apply -f /etc/kubernetes/kube-ovn.yaml --force", true, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "deploy kube-ovn.yaml failed")
 	}
@@ -136,7 +136,7 @@ type DeployNetworkMultusPlugin struct {
 }
 
 func (d *DeployNetworkMultusPlugin) Execute(runtime connector.Runtime) error {
-	if _, err := runtime.GetRunner().Host.SudoCmd(
+	if _, err := runtime.GetRunner().SudoCmd(
 		"/usr/local/bin/kubectl apply -f /etc/kubernetes/multus-network-plugin.yaml --force", true, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "deploy multus network plugin failed")
 	}
@@ -148,7 +148,7 @@ type LabelNode struct {
 }
 
 func (l *LabelNode) Execute(runtime connector.Runtime) error {
-	if _, err := runtime.GetRunner().Host.SudoCmd(
+	if _, err := runtime.GetRunner().SudoCmd(
 		fmt.Sprintf("/usr/local/bin/kubectl label no -l%s kube-ovn/role=master --overwrite",
 			l.KubeConf.Cluster.Network.Kubeovn.Label),
 		true, false); err != nil {
@@ -162,7 +162,7 @@ type GenerateSSL struct {
 }
 
 func (g *GenerateSSL) Execute(runtime connector.Runtime) error {
-	if exist, err := runtime.GetRunner().Host.SudoCmd(
+	if exist, err := runtime.GetRunner().SudoCmd(
 		"/usr/local/bin/kubectl get secret -n kube-system kube-ovn-tls --ignore-not-found",
 		true, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "find ovn secret failed")
@@ -170,14 +170,14 @@ func (g *GenerateSSL) Execute(runtime connector.Runtime) error {
 		return nil
 	}
 
-	if _, err := runtime.GetRunner().Host.SudoCmd(
+	if _, err := runtime.GetRunner().SudoCmd(
 		fmt.Sprintf("docker run --rm -v %s:/etc/ovn %s bash generate-ssl.sh",
 			runtime.GetWorkDir(), images.GetImage(runtime, g.KubeConf, "kubeovn").ImageName()),
 		true, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "generate ovn secret failed")
 	}
 
-	if _, err := runtime.GetRunner().Host.SudoCmd(
+	if _, err := runtime.GetRunner().SudoCmd(
 		fmt.Sprintf("/usr/local/bin/kubectl create secret generic -n kube-system kube-ovn-tls "+
 			"--from-file=cacert=%s/cacert.pem "+
 			"--from-file=cert=%s/ovn-cert.pem "+
@@ -187,7 +187,7 @@ func (g *GenerateSSL) Execute(runtime connector.Runtime) error {
 		return errors.Wrap(errors.WithStack(err), "create ovn secret failed")
 	}
 
-	if _, err := runtime.GetRunner().Host.SudoCmd(
+	if _, err := runtime.GetRunner().SudoCmd(
 		fmt.Sprintf("rm -rf %s/cacert.pem %s/ovn-cert.pem %s/ovn-privkey.pem %s/ovn-req.pem",
 			runtime.GetWorkDir(), runtime.GetWorkDir(), runtime.GetWorkDir(), runtime.GetWorkDir()),
 		true, false); err != nil {
@@ -202,14 +202,14 @@ type GenerateKubeOVN struct {
 }
 
 func (g *GenerateKubeOVN) Execute(runtime connector.Runtime) error {
-	address, err := runtime.GetRunner().Host.Cmd(
+	address, err := runtime.GetRunner().Cmd(
 		"/usr/local/bin/kubectl get no -lkube-ovn/role=master --no-headers -o wide | awk '{print $6}' | tr \\\\n ','",
 		true, false)
 	if err != nil {
 		return errors.Wrap(errors.WithStack(err), "get kube-ovn label node address failed")
 	}
 
-	count, err := runtime.GetRunner().Host.Cmd(
+	count, err := runtime.GetRunner().Cmd(
 		fmt.Sprintf("/usr/local/bin/kubectl get no -l%s --no-headers -o wide | wc -l | sed 's/ //g'",
 			g.KubeConf.Cluster.Network.Kubeovn.Label), true, false)
 	if err != nil {
@@ -301,7 +301,7 @@ type ChmodKubectlKo struct {
 }
 
 func (c *ChmodKubectlKo) Execute(runtime connector.Runtime) error {
-	if _, err := runtime.GetRunner().Host.SudoCmd(
+	if _, err := runtime.GetRunner().SudoCmd(
 		fmt.Sprintf("chmod +x %s", filepath.Join(common.BinDir, templates.KubectlKo.Name())), false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "chmod +x kubectl-ko failed")
 	}

--- a/pkg/plugins/nfd.go
+++ b/pkg/plugins/nfd.go
@@ -693,7 +693,7 @@ type ApplyNodeFeatureDiscoveryManifests struct {
 }
 
 func (a *ApplyNodeFeatureDiscoveryManifests) Execute(runtime connector.Runtime) error {
-	if _, err := runtime.GetRunner().Host.SudoCmd("/usr/local/bin/kubectl apply -f /etc/kubernetes/addons/node-feature-discovery.yaml", true, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd("/usr/local/bin/kubectl apply -f /etc/kubernetes/addons/node-feature-discovery.yaml", true, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "apply node-feature-discovery manifests failed")
 	}
 	return nil

--- a/pkg/plugins/storage/prepares.go
+++ b/pkg/plugins/storage/prepares.go
@@ -30,7 +30,7 @@ type CheckDefaultStorageClass struct {
 }
 
 func (c *CheckDefaultStorageClass) PreCheck(runtime connector.Runtime) (bool, error) {
-	output, err := runtime.GetRunner().Host.SudoCmd(
+	output, err := runtime.GetRunner().SudoCmd(
 		"/usr/local/bin/kubectl get sc --no-headers | grep '(default)' | wc -l", false, false)
 	if err != nil {
 		return false, errors.Wrap(errors.WithStack(err), "check default storageClass failed")

--- a/pkg/plugins/storage/tasks.go
+++ b/pkg/plugins/storage/tasks.go
@@ -31,7 +31,7 @@ type DeployLocalVolume struct {
 
 func (d *DeployLocalVolume) Execute(runtime connector.Runtime) error {
 	cmd := fmt.Sprintf("/usr/local/bin/kubectl apply -f %s", filepath.Join(common.KubeAddonsDir, "local-volume.yaml"))
-	if _, err := runtime.GetRunner().Host.SudoCmd(cmd, false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(cmd, false, false); err != nil {
 		return errors.Wrap(errors.WithStack(err), "deploy local-volume.yaml failed")
 	}
 	return nil

--- a/pkg/storage/minio.go
+++ b/pkg/storage/minio.go
@@ -24,7 +24,7 @@ type CheckMinioState struct {
 
 func (t *CheckMinioState) Execute(runtime connector.Runtime) error {
 	var cmd = "systemctl --no-pager -n 0 status minio" //
-	_, err := runtime.GetRunner().Host.SudoCmd(cmd, false, false)
+	_, err := runtime.GetRunner().SudoCmd(cmd, false, false)
 	if err != nil {
 		return fmt.Errorf("Minio Pending")
 	}
@@ -37,17 +37,17 @@ type EnableMinio struct {
 }
 
 func (t *EnableMinio) Execute(runtime connector.Runtime) error {
-	_, _ = runtime.GetRunner().Host.SudoCmd("groupadd -r minio", false, false)
-	_, _ = runtime.GetRunner().Host.SudoCmd("useradd -M -r -g minio minio", false, false)
-	_, _ = runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("chown minio:minio %s", MinioDataDir), false, false)
+	_, _ = runtime.GetRunner().SudoCmd("groupadd -r minio", false, false)
+	_, _ = runtime.GetRunner().SudoCmd("useradd -M -r -g minio minio", false, false)
+	_, _ = runtime.GetRunner().SudoCmd(fmt.Sprintf("chown minio:minio %s", MinioDataDir), false, false)
 
-	if _, err := runtime.GetRunner().Host.SudoCmd("systemctl daemon-reload", false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd("systemctl daemon-reload", false, false); err != nil {
 		return err
 	}
-	if _, err := runtime.GetRunner().Host.SudoCmd("systemctl restart minio", false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd("systemctl restart minio", false, false); err != nil {
 		return err
 	}
-	if _, err := runtime.GetRunner().Host.SudoCmd("systemctl enable minio", false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd("systemctl enable minio", false, false); err != nil {
 		return err
 	}
 
@@ -155,7 +155,7 @@ func (t *InstallMinio) Execute(runtime connector.Runtime) error {
 
 	// var cmd = fmt.Sprintf("cd %s && chmod +x minio && install minio /usr/local/bin", minio.BaseDir)
 	var cmd = fmt.Sprintf("cp -f %s /tmp/minio && chmod +x /tmp/minio && install /tmp/minio /usr/local/bin", path)
-	if _, err := runtime.GetRunner().Host.SudoCmd(cmd, false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(cmd, false, false); err != nil {
 		return err
 	}
 

--- a/pkg/storage/minio_operator.go
+++ b/pkg/storage/minio_operator.go
@@ -55,10 +55,10 @@ func (t *InstallMinioOperator) Execute(runtime connector.Runtime) error {
 		}
 	}
 
-	if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("tar zxvf %s", binary.Path()), false, true); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("tar zxvf %s", binary.Path()), false, true); err != nil {
 		return err
 	}
-	if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("install -m 755 %s/minio-operator %s", binary.BaseDir, MinioOperatorFile), false, true); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("install -m 755 %s/minio-operator %s", binary.BaseDir, MinioOperatorFile), false, true); err != nil {
 		return err
 	}
 
@@ -69,7 +69,7 @@ func (t *InstallMinioOperator) Execute(runtime connector.Runtime) error {
 		MinioOperatorFile, localIp, runtime.RemoteHost().GetName(),
 		runtime.RemoteHost().GetName(), minioData, minioPassword)
 
-	if _, err := runtime.GetRunner().Host.SudoCmd(cmd, false, true); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(cmd, false, true); err != nil {
 		return err
 	}
 

--- a/pkg/storage/tasks.go
+++ b/pkg/storage/tasks.go
@@ -26,13 +26,13 @@ type MkStorageDir struct {
 func (t *MkStorageDir) Execute(runtime connector.Runtime) error {
 	if utils.IsExist(StorageDataDir) {
 		if utils.IsExist(cc.OlaresDir) {
-			_, _ = runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("rm -rf %s", cc.OlaresDir), false, false)
+			_, _ = runtime.GetRunner().SudoCmd(fmt.Sprintf("rm -rf %s", cc.OlaresDir), false, false)
 		}
 
-		if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("mkdir -p %s", StorageDataOlaresDir), false, false); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("mkdir -p %s", StorageDataOlaresDir), false, false); err != nil {
 			return err
 		}
-		if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("ln -s %s %s", StorageDataOlaresDir, cc.OlaresDir), false, false); err != nil {
+		if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("ln -s %s %s", StorageDataOlaresDir, cc.OlaresDir), false, false); err != nil {
 			return err
 		}
 	}
@@ -46,7 +46,7 @@ type DownloadStorageCli struct {
 
 func (t *DownloadStorageCli) Execute(runtime connector.Runtime) error {
 	if _, err := util.GetCommand(common.CommandUnzip); err != nil {
-		runtime.GetRunner().Host.SudoCmd("apt install -y unzip", false, true)
+		runtime.GetRunner().SudoCmd("apt install -y unzip", false, true)
 	}
 
 	var storageType = t.KubeConf.Arg.Storage.StorageType
@@ -134,7 +134,7 @@ func (t *UnMountS3) Execute(runtime connector.Runtime) error {
 		storageAccessKey, storageSecretKey, storageToken, endpoint, storageClusterId,
 	)
 
-	if _, err := runtime.GetRunner().Host.SudoCmd(cmd, false, true); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(cmd, false, true); err != nil {
 		logger.Errorf("failed to unmount s3 bucket %s: %v", storageBucket, err)
 	}
 
@@ -176,7 +176,7 @@ func (t *UnMountOSS) Execute(runtime connector.Runtime) error {
 
 	var cmd = fmt.Sprintf("/usr/local/sbin/ossutil64 rm %s/%s/ --endpoint=%s --access-key-id=%s --access-key-secret=%s --sts-token=%s -r -f", ossName, storageClusterId, ossEndpoint, storageAccessKey, storageSecretKey, storageToken)
 
-	if _, err := runtime.GetRunner().Host.SudoCmd(cmd, false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(cmd, false, false); err != nil {
 		logger.Errorf("failed to unmount oss bucket %s: %v", storageBucket, err)
 	}
 
@@ -213,7 +213,7 @@ func (t *UnMountCOS) Execute(runtime connector.Runtime) error {
 	cosEndpoint := fmt.Sprintf("%s.%s.%s.%s", s[1], s[2], s[3], s[4])
 	var cmd = fmt.Sprintf("/usr/local/bin/cosutil rm %s/%s/ --endpoint %s --secret-id %s --secret-key %s --token %s --init-skip -r -f", cosName, storageClusterId, cosEndpoint, storageAccessKey, storageSecretKey, storageToken)
 
-	if _, err := runtime.GetRunner().Host.SudoCmd(cmd, false, false); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(cmd, false, false); err != nil {
 		logger.Errorf("failed to unmount cos bucket %s: %v", storageBucket, err)
 	}
 
@@ -225,13 +225,13 @@ type StopJuiceFS struct {
 }
 
 func (t *StopJuiceFS) Execute(runtime connector.Runtime) error {
-	_, _ = runtime.GetRunner().Host.SudoCmd("systemctl stop juicefs; systemctl disable juicefs", false, false)
+	_, _ = runtime.GetRunner().SudoCmd("systemctl stop juicefs; systemctl disable juicefs", false, false)
 
-	_, _ = runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("rm -rf /var/jfsCache %s", JuiceFsCacheDir), false, false)
+	_, _ = runtime.GetRunner().SudoCmd(fmt.Sprintf("rm -rf /var/jfsCache %s", JuiceFsCacheDir), false, false)
 
-	_, _ = runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("umount %s", OlaresJuiceFSRootDir), false, false)
+	_, _ = runtime.GetRunner().SudoCmd(fmt.Sprintf("umount %s", OlaresJuiceFSRootDir), false, false)
 
-	_, _ = runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("rm -rf %s", OlaresJuiceFSRootDir), false, false)
+	_, _ = runtime.GetRunner().SudoCmd(fmt.Sprintf("rm -rf %s", OlaresJuiceFSRootDir), false, false)
 
 	return nil
 }
@@ -241,7 +241,7 @@ type StopMinio struct {
 }
 
 func (t *StopMinio) Execute(runtime connector.Runtime) error {
-	_, _ = runtime.GetRunner().Host.SudoCmd("systemctl stop minio; systemctl disable minio", false, false)
+	_, _ = runtime.GetRunner().SudoCmd("systemctl stop minio; systemctl disable minio", false, false)
 	return nil
 }
 
@@ -251,7 +251,7 @@ type StopMinioOperator struct {
 
 func (t *StopMinioOperator) Execute(runtime connector.Runtime) error {
 	var cmd = "systemctl stop minio-operator; systemctl disable minio-operator"
-	_, _ = runtime.GetRunner().Host.SudoCmd(cmd, false, false)
+	_, _ = runtime.GetRunner().SudoCmd(cmd, false, false)
 	return nil
 }
 
@@ -261,9 +261,9 @@ type StopRedis struct {
 
 func (t *StopRedis) Execute(runtime connector.Runtime) error {
 	var cmd = "systemctl stop redis-server; systemctl disable redis-server"
-	_, _ = runtime.GetRunner().Host.SudoCmd(cmd, false, false)
-	_, _ = runtime.GetRunner().Host.SudoCmd("killall -9 redis-server", false, false)
-	_, _ = runtime.GetRunner().Host.SudoCmd("unlink /usr/bin/redis-server; unlink /usr/bin/redis-cli", false, false)
+	_, _ = runtime.GetRunner().SudoCmd(cmd, false, false)
+	_, _ = runtime.GetRunner().SudoCmd("killall -9 redis-server", false, false)
+	_, _ = runtime.GetRunner().SudoCmd("unlink /usr/bin/redis-server; unlink /usr/bin/redis-cli", false, false)
 
 	return nil
 }
@@ -284,7 +284,7 @@ func (t *RemoveJuiceFSFiles) Execute(runtime connector.Runtime) error {
 	}
 
 	for _, f := range files {
-		runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("rm -rf %s", f), false, true)
+		runtime.GetRunner().SudoCmd(fmt.Sprintf("rm -rf %s", f), false, true)
 	}
 
 	return nil
@@ -303,7 +303,7 @@ func (t *RemoveTerminusFiles) Execute(runtime connector.Runtime) error {
 	}
 
 	for _, f := range files {
-		runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("rm -rf %s", f), false, true)
+		runtime.GetRunner().SudoCmd(fmt.Sprintf("rm -rf %s", f), false, true)
 	}
 
 	return nil
@@ -440,7 +440,7 @@ func (t *DeleteTerminusData) Execute(runtime connector.Runtime) error {
 	}
 
 	if util.IsExist(StorageDataDir) {
-		runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("umount %s", StorageDataDir), false, true)
+		runtime.GetRunner().SudoCmd(fmt.Sprintf("umount %s", StorageDataDir), false, true)
 		if err := util.RemoveDir(StorageDataDir); err != nil {
 			logger.Errorf("remove %s failed %v", StorageDataDir, err)
 		}

--- a/pkg/terminus/apps.go
+++ b/pkg/terminus/apps.go
@@ -195,7 +195,7 @@ type ClearAppValues struct {
 
 func (c *ClearAppValues) Execute(runtime connector.Runtime) error {
 	// clear apps values.yaml
-	_, _ = runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("cat /dev/null > %s/wizard/config/apps/values.yaml", runtime.GetInstallerDir()), false, false)
+	_, _ = runtime.GetRunner().SudoCmd(fmt.Sprintf("cat /dev/null > %s/wizard/config/apps/values.yaml", runtime.GetInstallerDir()), false, false)
 
 	return nil
 }
@@ -218,7 +218,7 @@ func (c *CopyAppServiceHelmFiles) Execute(runtime connector.Runtime) error {
 	kubeclt, _ := util.GetCommand(common.CommandKubectl)
 	for _, app := range []string{"launcher", "apps"} {
 		var cmd = fmt.Sprintf("%s cp %s/wizard/config/%s os-system/%s:/userapps -c app-service", kubeclt, runtime.GetInstallerDir(), app, appServiceName)
-		if _, err = runtime.GetRunner().Host.SudoCmd(cmd, false, true); err != nil {
+		if _, err = runtime.GetRunner().SudoCmd(cmd, false, true); err != nil {
 			return errors.Wrap(errors.WithStack(err), "copy files failed")
 		}
 	}
@@ -258,7 +258,7 @@ func getBflPod(ctx context.Context, ns string, client clientset.Client, runtime 
 func getDocUrl(ctx context.Context, runtime connector.Runtime) (url string, err error) {
 	var nodeip string
 	var cmd = fmt.Sprintf(`curl --connect-timeout 30 --retry 5 --retry-delay 1 --retry-max-time 10 -s http://checkip.dyndns.org/ | grep -o "[[:digit:].]\+"`)
-	nodeip, _ = runtime.GetRunner().Host.SudoCmdContext(ctx, cmd, false, false)
+	nodeip, _ = runtime.GetRunner().SudoCmdContext(ctx, cmd, false, false)
 	url = fmt.Sprintf("http://%s:30883/bfl/apidocs.json", nodeip)
 	return
 }

--- a/pkg/terminus/launcher.go
+++ b/pkg/terminus/launcher.go
@@ -103,7 +103,8 @@ func (m *InstallLauncherModule) Init() {
 		Name:   "InstallLauncher",
 		Desc:   "InstallLauncher",
 		Action: new(InstallBFL),
-		Retry:  1,
+		Retry:  3,
+		Delay:  30 * time.Second,
 	}
 
 	checkBFLRunning := &task.LocalTask{

--- a/pkg/terminus/velero.go
+++ b/pkg/terminus/velero.go
@@ -41,7 +41,7 @@ func (t *InstallVeleroBinary) Execute(runtime connector.Runtime) error {
 	path := veleroPkg.FilePath(baseDir)
 
 	var cmd = fmt.Sprintf("rm -rf /tmp/velero* && mkdir /tmp/velero && cp %s /tmp/%s && tar xf /tmp/%s -C /tmp/velero ", path, veleroPkg.Filename, veleroPkg.Filename)
-	if _, err := runtime.GetRunner().Host.SudoCmd(cmd, false, true); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(cmd, false, true); err != nil {
 		return err
 	}
 	var binPath string
@@ -58,7 +58,7 @@ func (t *InstallVeleroBinary) Execute(runtime connector.Runtime) error {
 		return nil
 	})
 	cmd = fmt.Sprintf("install %s /usr/local/bin", binPath)
-	if _, err := runtime.GetRunner().Host.SudoCmd(cmd, false, true); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(cmd, false, true); err != nil {
 		return err
 	}
 	return nil
@@ -74,7 +74,7 @@ func (i *InstallVeleroCRDs) Execute(runtime connector.Runtime) error {
 		return errors.Wrap(errors.WithStack(err), "velero not found")
 	}
 
-	if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("%s install --crds-only --retry 10 --delay 5", velero), false, true); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(fmt.Sprintf("%s install --crds-only --retry 10 --delay 5", velero), false, true); err != nil {
 		return errors.Wrap(errors.WithStack(err), "install velero crds failed")
 	}
 
@@ -97,13 +97,13 @@ func (c *CreateBackupLocation) Execute(runtime connector.Runtime) error {
 	var storage = "terminus-cloud"
 
 	var cmd = fmt.Sprintf("%s backup-location get -n %s -l 'name=%s'", velero, ns, storage)
-	if res, err := runtime.GetRunner().Host.SudoCmd(cmd, false, true); err == nil && res != "" {
+	if res, err := runtime.GetRunner().SudoCmd(cmd, false, true); err == nil && res != "" {
 		return nil
 	}
 
 	cmd = fmt.Sprintf("%s backup-location create %s --provider %s --namespace %s --prefix '' --bucket %s --labels name=%s",
 		velero, storage, provider, ns, storage, storage)
-	if _, err := runtime.GetRunner().Host.SudoCmd(cmd, false, true); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(cmd, false, true); err != nil {
 		return errors.Wrap(errors.WithStack(err), "create backup-location failed")
 	}
 
@@ -124,7 +124,7 @@ func (i *InstallVeleroPlugin) Execute(runtime connector.Runtime) error {
 
 	var ns = "os-system"
 	var cmd = fmt.Sprintf("%s plugin get -n %s |grep 'velero.io/terminus' |wc -l", velero, ns)
-	pluginCounts, _ := runtime.GetRunner().Host.SudoCmd(cmd, false, true)
+	pluginCounts, _ := runtime.GetRunner().SudoCmd(cmd, false, true)
 	if counts := utils.ParseInt(pluginCounts); counts > 0 {
 		return nil
 	}
@@ -138,12 +138,12 @@ func (i *InstallVeleroPlugin) Execute(runtime connector.Runtime) error {
 
 	cmd = fmt.Sprintf("%s install --no-default-backup-location --namespace %s --image beclab/velero:%s --use-volume-snapshots=false --no-secret --plugins beclab/velero-plugin-for-terminus:%s --velero-pod-cpu-request=10m --velero-pod-cpu-limit=200m --node-agent-pod-cpu-request=10m --node-agent-pod-cpu-limit=200m --wait --wait-minute 30 %s", velero, ns, veleroVersion, veleroPluginVersion, args)
 
-	if _, err := runtime.GetRunner().Host.SudoCmd(cmd, false, true); err != nil {
+	if _, err := runtime.GetRunner().SudoCmd(cmd, false, true); err != nil {
 		return errors.Wrap(errors.WithStack(err), "velero install plugin error")
 	}
 
 	// cmd = fmt.Sprintf("%s plugin add beclab/velero-plugin-for-terminus:%s -n %s", velero, veleroPluginVersion, ns)
-	// if stdout, _ := runtime.GetRunner().Host.SudoCmd(cmd, false, true); stdout != "" && !strings.Contains(stdout, "Duplicate") {
+	// if stdout, _ := runtime.GetRunner().SudoCmd(cmd, false, true); stdout != "" && !strings.Contains(stdout, "Duplicate") {
 	// 	logger.Debug(stdout)
 	// }
 
@@ -161,9 +161,9 @@ func (v *PatchVelero) Execute(runtime connector.Runtime) error {
 	}
 
 	var ns = "os-system"
-	var patch = "[{\\\"op\\\":\\\"replace\\\",\\\"path\\\":\\\"/spec/template/spec/volumes\\\",\\\"value\\\": [{\\\"name\\\":\\\"plugins\\\",\\\"emptyDir\\\":{}},{\\\"name\\\":\\\"scratch\\\",\\\"emptyDir\\\":{}},{\\\"name\\\":\\\"terminus-cloud\\\",\\\"hostPath\\\":{\\\"path\\\":\\\"/olares/rootfs/k8s-backup\\\", \\\"type\\\":\\\"DirectoryOrCreate\\\"}}]},{\\\"op\\\": \\\"replace\\\", \\\"path\\\": \\\"/spec/template/spec/containers/0/volumeMounts\\\", \\\"value\\\": [{\\\"name\\\":\\\"plugins\\\",\\\"mountPath\\\":\\\"/plugins\\\"},{\\\"name\\\":\\\"scratch\\\",\\\"mountPath\\\":\\\"/scratch\\\"},{\\\"mountPath\\\":\\\"/data\\\",\\\"name\\\":\\\"terminus-cloud\\\"}]},{\\\"op\\\": \\\"replace\\\", \\\"path\\\": \\\"/spec/template/spec/containers/0/securityContext\\\", \\\"value\\\": {\\\"privileged\\\": true, \\\"runAsNonRoot\\\": false, \\\"runAsUser\\\": 0}}]"
+	var patch = `[{"op":"replace","path":"/spec/template/spec/volumes","value": [{"name":"plugins","emptyDir":{}},{"name":"scratch","emptyDir":{}},{"name":"terminus-cloud","hostPath":{"path":"/olares/rootfs/k8s-backup", "type":"DirectoryOrCreate"}}]},{"op": "replace", "path": "/spec/template/spec/containers/0/volumeMounts", "value": [{"name":"plugins","mountPath":"/plugins"},{"name":"scratch","mountPath":"/scratch"},{"mountPath":"/data","name":"terminus-cloud"}]},{"op": "replace", "path": "/spec/template/spec/containers/0/securityContext", "value": {"privileged": true, "runAsNonRoot": false, "runAsUser": 0}}]`
 
-	if stdout, _ := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("%s patch deploy velero -n %s --type='json' -p='%s'", kubectl, ns, patch), false, true); stdout != "" && !strings.Contains(stdout, "patched") {
+	if stdout, _ := runtime.GetRunner().SudoCmd(fmt.Sprintf("%s patch deploy velero -n %s --type='json' -p='%s'", kubectl, ns, patch), false, true); stdout != "" && !strings.Contains(stdout, "patched") {
 		logger.Errorf("velero plugin patched error %s", stdout)
 	}
 

--- a/pkg/terminus/welcome.go
+++ b/pkg/terminus/welcome.go
@@ -82,7 +82,7 @@ func (m *WelcomeModule) Init() {
 	waitServicesReady := &task.LocalTask{
 		Name:   "WaitServicesReady",
 		Action: new(CheckKeyPodsRunning),
-		Retry:  30,
+		Retry:  60,
 		Delay:  15 * time.Second,
 	}
 

--- a/pkg/utils/gpu.go
+++ b/pkg/utils/gpu.go
@@ -190,7 +190,7 @@ func ExecNvidiaSmi(execRuntime connector.Runtime) (gpuInfo *NvidiaGpuInfo, insta
 		}
 	}
 
-	out, err := execRuntime.GetRunner().Host.SudoCmd(cmdPath+" -q -x", false, false)
+	out, err := execRuntime.GetRunner().SudoCmd(cmdPath+" -q -x", false, false)
 	if err != nil {
 		// when nvidia-smi command is installed but cuda is not installed
 		if strings.Contains(out, "couldn't communicate with the NVIDIA driver") {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -47,7 +47,7 @@ const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 type Data map[string]interface{}
 
 func ResetTmpDir(runtime connector.Runtime) error {
-	_, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf(
+	_, err := runtime.GetRunner().SudoCmd(fmt.Sprintf(
 		"if [ -d %s ]; then rm -rf %s ;fi && mkdir -m 777 -p %s",
 		common.TmpDir, common.TmpDir, common.TmpDir), false, false)
 	if err != nil {


### PR DESCRIPTION
two node-related commands are added:
- `olares-cli node masterinfo` for getting information about a target master node, and checks whether current node can be added to the cluster.
- `olares-cli node add` for adding current node to the Kubernetes cluster as a worker node.

both commands share a same set of options that specify how to access the master node by SSH:
| option | explain | required | default |
|---|---|---|---|
| master-host | the IP address of the master node | true | |
| master-node-name | the Kubernetes node name of the master node| false | false | auto retrieved |
| master-ssh-user | the Linux user name to login to the master node by SSH | false | root |
| master-ssh-password | the password of the Linux user | true for non-root master-ssh-user | |
| master-ssh-private-key-path | the private SSH key to authenticate as the Linux user | false | $HOME/.ssh/id_rsa |
| master-ssh-port | the listening port of the SSH service on the master node | false | 22 | 

some changes at the framework level is made, to make it possible to operate on two nodes simultaneously, in order to add worker node:

previously, in https://github.com/beclab/Installer/commit/77254472ed6e43fa3bd26238c4f82df1425e587a and https://github.com/beclab/Installer/commit/a550861d1ddfe055a988415d39d912f6f9df4146:

a `RemoteTask` is made effectively the same as a `LocalTask` in that it does not use a SSH connection:
https://github.com/beclab/Installer/blob/0ef8cea6b7eabd48eb3dc500d4123ea33eadfa9f/pkg/core/task/remote_task.go#L164-L182

and all remote commands (via SSH connection by `runtime.GetRunner().Cmd()`) are changed to run locally (by `runtime.GetRunner().Host.Cmd()`)

these changes are partially reverted and partially merged into the original code, specifically, `RemoteTask` and `LocalTask` are made more interchangeable by:
- when initiating a `RemoteTask`, if the target host is not the local machine, a SSH connection is established, otherwise a `nil` connection is passed to the `Runner`, indicating it's running on a local machine
- when initiating a `LocalTask`, a real `host` is fetched from the runtime's host map first, instead of the current dummy localhost, to retain the host's roles
- when calling methods like `runtime.GetRunner().Cmd()`, the Runner's connection field is checked, if one exists, the SSH connection is used to execute the command, otherwise, the command is passed to Runner's host to execute locally.
- all `runtime.GetRunner().Host.Cmd()` is changed back to `runtime.GetRunner().Cmd()`
- when calling methods like `runtime.GetRunner().SudoCmd()`, the host's user is checked, a `sudo` prefix is added to the command only if the user is not root

some other module level changes are made to adjust the new cases for a worker node, when it needs to install JuiceFS based on a remote Redis server, and when the storage and K8s services need reconfiguration when its IP changes