### PR TITLE
fix: set the TERMINUS_OS_DOMAINNAME environment

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -287,6 +287,7 @@ const (
 	ENV_PREINSTALL                  = "PREINSTALL"
 	ENV_DISABLE_HOST_IP_PROMPT      = "DISABLE_HOST_IP_PROMPT"
 	ENV_AUTO_ADD_FIREWALL_RULES     = "AUTO_ADD_FIREWALL_RULES"
+	ENV_TERMINUS_OS_DOMAINNAME      = "TERMINUS_OS_DOMAINNAME"
 )
 
 // TerminusGlobalEnvs holds a group of general environment variables

--- a/pkg/windows/tasks.go
+++ b/pkg/windows/tasks.go
@@ -333,6 +333,14 @@ func (i *InstallTerminus) Execute(runtime connector.Runtime) error {
 		fmt.Sprintf("export %s=%s", common.ENV_DOWNLOAD_CDN_URL, i.KubeConf.Arg.DownloadCdnUrl),
 	}
 
+	var defaultDomainName = os.Getenv(common.ENV_TERMINUS_OS_DOMAINNAME)
+	if !utils.IsValidDomain(defaultDomainName) {
+		defaultDomainName = ""
+	}
+	if defaultDomainName != "" {
+		envs = append(envs, fmt.Sprintf("export %s=%s", common.ENV_TERMINUS_OS_DOMAINNAME, defaultDomainName))
+	}
+
 	for key, val := range common.TerminusGlobalEnvs {
 		envs = append(envs, fmt.Sprintf("export %s=%s", key, val))
 	}


### PR DESCRIPTION
when installing the WSL version of Olares, when prompted to enter the Domain Name, the default value set in the environment variable TERMINUS_OS_DOMAINNAME can be used.