### PR TITLE
fix: handle the case where nvidia-smi is installed but no cuda driver

### DIFF
--- a/pkg/gpu/tasks.go
+++ b/pkg/gpu/tasks.go
@@ -648,15 +648,15 @@ func (t *RestartPlugin) Execute(runtime connector.Runtime) error {
 		return fmt.Errorf("kubectl not found")
 	}
 
-	if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("%s scale ds nvshare-device-plugin -n nvshare-system", kubectlpath), false, true); err != nil {
+	if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("%s rollout restart ds nvshare-device-plugin -n nvshare-system", kubectlpath), false, true); err != nil {
 		return errors.Wrap(errors.WithStack(err), "Failed to restart nvshare-device-plugin")
 	}
 
-	if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("%s scale ds nvshare-scheduler -n nvshare-system", kubectlpath), false, true); err != nil {
+	if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("%s rollout restart ds nvshare-scheduler -n nvshare-system", kubectlpath), false, true); err != nil {
 		return errors.Wrap(errors.WithStack(err), "Failed to restart nvshare-scheduler")
 	}
 
-	if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("%s scale ds nvidia-device-plugin -n kube-system", kubectlpath), false, true); err != nil {
+	if _, err := runtime.GetRunner().Host.SudoCmd(fmt.Sprintf("%s rollout restart ds nvidia-device-plugin -n kube-system", kubectlpath), false, true); err != nil {
 		return errors.Wrap(errors.WithStack(err), "Failed to restart nvidia-device-plugin")
 	}
 

--- a/pkg/utils/gpu.go
+++ b/pkg/utils/gpu.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"strings"
 
 	"bytetrade.io/web3os/installer/pkg/core/connector"
 	"k8s.io/klog/v2"
@@ -191,6 +192,10 @@ func ExecNvidiaSmi(execRuntime connector.Runtime) (gpuInfo *NvidiaGpuInfo, insta
 
 	out, err := execRuntime.GetRunner().Host.SudoCmd(cmdPath+" -q -x", false, false)
 	if err != nil {
+		// when nvidia-smi command is installed but cuda is not installed
+		if strings.Contains(out, "couldn't communicate with the NVIDIA driver") {
+			return nil, false, nil
+		}
 		klog.Error("Error running nvidia-smi:", err)
 		return nil, false, err
 	}


### PR DESCRIPTION
- when the `nvidia-smi` command is installed but cuda driver is not installed, execution of `nvidia-smi` will result into an error, which should also be handled as a case of cuda driver not found.
- the current method of restarting the gpu plugins does not work.
 