### PR TITLE
fix: use global supported cuda version

### DIFF
--- a/pkg/bootstrap/precheck/module.go
+++ b/pkg/bootstrap/precheck/module.go
@@ -83,7 +83,7 @@ func (m *RunPrechecksModule) Init() {
 		new(SystemdCheck),
 		new(RequiredPortsCheck),
 		new(ConflictingContainerdCheck),
-		&CudaChecker{CudaCheckTask{SupportedCudaVersion: common.DefaultCudaVersion}},
+		new(CudaChecker),
 	}
 	runPreChecks := &task.LocalTask{
 		Name: "RunPrechecks",

--- a/pkg/bootstrap/precheck/tasks.go
+++ b/pkg/bootstrap/precheck/tasks.go
@@ -524,15 +524,14 @@ func (t *RemoveChattr) Execute(runtime connector.Runtime) error {
 
 var ErrUnsupportedCudaVersion = errors.New("cuda version is too old, please install at least version 12.4")
 var ErrCudaInstalled = errors.New("cuda is installed")
+var supportedCudaVersions = []string{"12.4", "12.5", "12.6"}
 
 // CudaCheckTask checks the cuda version, if the current version is not supported, it will return an error
 // before executing the command `olares-cli gpu install`, we need to check the cuda version
 // if the cuda if not installed, it will return nil and the command can be executed.
 // if the cuda is installed and the version is unsupported, the command can not be executed,
 // or the cuda version is supported, executing the command is unnecessary.
-type CudaCheckTask struct {
-	SupportedCudaVersion []string
-}
+type CudaCheckTask struct{}
 
 func (t *CudaCheckTask) Name() string {
 	return "Cuda"
@@ -552,8 +551,8 @@ func (t *CudaCheckTask) Execute(runtime connector.Runtime) error {
 		return nil
 	default:
 		logger.Infof("NVIDIA driver is installed, version: %s, cuda version: %s", info.DriverVersion, info.CudaVersion)
-		oldestVer := semver.MustParse(t.SupportedCudaVersion[0])
-		newestVer := semver.MustParse(t.SupportedCudaVersion[len(t.SupportedCudaVersion)-1])
+		oldestVer := semver.MustParse(supportedCudaVersions[0])
+		newestVer := semver.MustParse(supportedCudaVersions[len(supportedCudaVersions)-1])
 		currentVer := semver.MustParse(info.CudaVersion)
 		if oldestVer.GreaterThan(currentVer) {
 			return ErrUnsupportedCudaVersion

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -167,9 +167,8 @@ const (
 )
 
 var (
-	CloudVendor                 = os.Getenv("CLOUD_VENDOR")
-	ResolvProxy                 = os.Getenv("PROXY")
-	DefaultCudaVersion []string = []string{"12.4", "12.5", "12.6"}
+	CloudVendor = os.Getenv("CLOUD_VENDOR")
+	ResolvProxy = os.Getenv("PROXY")
 )
 
 const (

--- a/pkg/gpu/module.go
+++ b/pkg/gpu/module.go
@@ -3,7 +3,6 @@ package gpu
 import (
 	"time"
 
-	"bytetrade.io/web3os/installer/pkg/bootstrap/precheck"
 	"bytetrade.io/web3os/installer/pkg/common"
 	"bytetrade.io/web3os/installer/pkg/core/prepare"
 	"bytetrade.io/web3os/installer/pkg/core/task"
@@ -27,11 +26,7 @@ func (m *InstallDriversModule) Init() {
 		Name:  "InstallCudaKeyRing",
 		Hosts: m.Runtime.GetHostsByRole(common.Master),
 		Prepare: &prepare.PrepareCollection{
-			&CudaNotInstalled{
-				CudaCheckTask: precheck.CudaCheckTask{
-					SupportedCudaVersion: common.DefaultCudaVersion,
-				},
-			},
+			new(CudaNotInstalled),
 			new(NvidiaGraphicsCard),
 		},
 		Action: &InstallCudaDeps{
@@ -48,11 +43,7 @@ func (m *InstallDriversModule) Init() {
 		Name:  "InstallNvidiaDriver",
 		Hosts: m.Runtime.GetHostsByRole(common.Master),
 		Prepare: &prepare.PrepareCollection{
-			&CudaNotInstalled{
-				CudaCheckTask: precheck.CudaCheckTask{
-					SupportedCudaVersion: common.DefaultCudaVersion,
-				},
-			},
+			new(CudaNotInstalled),
 			new(NvidiaGraphicsCard),
 		},
 		Action:   new(InstallCudaDriver),
@@ -80,15 +71,9 @@ func (m *InstallContainerToolkitModule) Init() {
 	m.Name = "InstallContainerToolkit"
 
 	updateCudaSource := &task.RemoteTask{
-		Name:  "UpdateNvidiaToolkitSource",
-		Hosts: m.Runtime.GetHostsByRole(common.Master),
-		Prepare: &prepare.PrepareCollection{
-			&CudaInstalled{
-				CudaCheckTask: precheck.CudaCheckTask{
-					SupportedCudaVersion: common.DefaultCudaVersion,
-				},
-			},
-		},
+		Name:    "UpdateNvidiaToolkitSource",
+		Hosts:   m.Runtime.GetHostsByRole(common.Master),
+		Prepare: new(CudaInstalled),
 		Action: &UpdateCudaSource{
 			ManifestAction: manifest.ManifestAction{
 				Manifest: m.Manifest,
@@ -103,11 +88,7 @@ func (m *InstallContainerToolkitModule) Init() {
 		Name:  "InstallNvidiaToolkit",
 		Hosts: m.Runtime.GetHostsByRole(common.Master),
 		Prepare: &prepare.PrepareCollection{
-			&CudaInstalled{
-				CudaCheckTask: precheck.CudaCheckTask{
-					SupportedCudaVersion: common.DefaultCudaVersion,
-				},
-			},
+			new(CudaInstalled),
 			new(ContainerdInstalled),
 		},
 		Action:   new(InstallNvidiaContainerToolkit),
@@ -119,11 +100,7 @@ func (m *InstallContainerToolkitModule) Init() {
 		Name:  "ConfigureContainerdRuntime",
 		Hosts: m.Runtime.GetHostsByRole(common.Master),
 		Prepare: &prepare.PrepareCollection{
-			&CudaInstalled{
-				CudaCheckTask: precheck.CudaCheckTask{
-					SupportedCudaVersion: common.DefaultCudaVersion,
-				},
-			},
+			new(CudaInstalled),
 			new(ContainerdInstalled),
 		},
 		Action:   new(ConfigureContainerdRuntime),
@@ -235,11 +212,7 @@ func (m *InstallPluginModule) Init() {
 		Hosts: m.Runtime.GetHostsByRole(common.Master),
 		Prepare: &prepare.PrepareCollection{
 			new(common.OnlyFirstMaster),
-			&CudaInstalled{
-				CudaCheckTask: precheck.CudaCheckTask{
-					SupportedCudaVersion: common.DefaultCudaVersion,
-				},
-			},
+			new(CudaInstalled),
 		},
 		Action:   new(CheckGpuStatus),
 		Parallel: false,
@@ -296,11 +269,7 @@ func (l *NodeLabelingModule) Init() {
 		Hosts: l.Runtime.GetHostsByRole(common.Master),
 		Prepare: &prepare.PrepareCollection{
 			new(common.OnlyFirstMaster),
-			&CudaInstalled{
-				CudaCheckTask: precheck.CudaCheckTask{
-					SupportedCudaVersion: common.DefaultCudaVersion,
-				},
-			},
+			new(CudaInstalled),
 			new(K8sNodeInstalled),
 		},
 		Action:   new(UpdateNodeLabels),
@@ -313,11 +282,7 @@ func (l *NodeLabelingModule) Init() {
 		Hosts: l.Runtime.GetHostsByRole(common.Master),
 		Prepare: &prepare.PrepareCollection{
 			new(common.OnlyFirstMaster),
-			&CudaInstalled{
-				CudaCheckTask: precheck.CudaCheckTask{
-					SupportedCudaVersion: common.DefaultCudaVersion,
-				},
-			},
+			new(CudaInstalled),
 			new(K8sNodeInstalled),
 		},
 		Action:   new(RestartPlugin),
@@ -355,11 +320,7 @@ func (l *NodeUnlabelingModule) Init() {
 		Hosts: l.Runtime.GetHostsByRole(common.Master),
 		Prepare: &prepare.PrepareCollection{
 			new(common.OnlyFirstMaster),
-			&CudaInstalled{
-				CudaCheckTask: precheck.CudaCheckTask{
-					SupportedCudaVersion: common.DefaultCudaVersion,
-				},
-			},
+			new(CudaInstalled),
 			new(K8sNodeInstalled),
 			new(GpuDevicePluginInstalled),
 		},
@@ -386,11 +347,7 @@ func (l *UninstallCudaModule) Init() {
 		Hosts: l.Runtime.GetHostsByRole(common.Master),
 		Prepare: &prepare.PrepareCollection{
 			new(common.OnlyFirstMaster),
-			&CudaInstalled{
-				CudaCheckTask: precheck.CudaCheckTask{
-					SupportedCudaVersion: common.DefaultCudaVersion,
-				},
-			},
+			new(CudaInstalled),
 		},
 		Action:   new(UninstallNvidiaDrivers),
 		Parallel: false,

--- a/pkg/gpu/tasks.go
+++ b/pkg/gpu/tasks.go
@@ -189,6 +189,9 @@ type PatchK3sDriver struct { // patch k3s on wsl
 }
 
 func (t *PatchK3sDriver) Execute(runtime connector.Runtime) error {
+	if !runtime.GetSystemInfo().IsWsl() {
+		return nil
+	}
 	var cmd = "find /usr/lib/wsl/drivers/ -name libcuda.so.1.1|head -1"
 	driverPath, err := runtime.GetRunner().Host.SudoCmd(cmd, false, true)
 	if err != nil {


### PR DESCRIPTION
the current `CudaCheckTask` has a field `SupportedCudaVersion` of type `[]string`, which is effectively a same list throughout the whole project, but has to be explicitly assigned a value, this assignment is likely to be missed by developers, we can just use a global variable to avoid such cases.