### PR TITLE
fix: let package manager decide the version of nvidia driver

### DIFF
--- a/pkg/bootstrap/precheck/tasks.go
+++ b/pkg/bootstrap/precheck/tasks.go
@@ -522,9 +522,9 @@ func (t *RemoveChattr) Execute(runtime connector.Runtime) error {
 	return nil
 }
 
-var ErrUnsupportedCudaVersion = errors.New("cuda version is too old, please install at least version 12.4")
+var ErrUnsupportedCudaVersion = errors.New("cuda version is too old, please install at least version 12.4, or you can uninstall it, REBOOT your machine, and let Olares install a new version for you.")
 var ErrCudaInstalled = errors.New("cuda is installed")
-var supportedCudaVersions = []string{"12.4", "12.5", "12.6"}
+var supportedCudaVersions = []string{"12.4", "12.5", "12.6", "12.7"}
 
 // CudaCheckTask checks the cuda version, if the current version is not supported, it will return an error
 // before executing the command `olares-cli gpu install`, we need to check the cuda version

--- a/pkg/gpu/prepares.go
+++ b/pkg/gpu/prepares.go
@@ -106,7 +106,7 @@ func (p *NvidiaGraphicsCard) PreCheck(runtime connector.Runtime) (bool, error) {
 		return false, nil
 	}
 	output, err := runtime.GetRunner().Host.SudoCmd(
-		"lspci | grep VGA | grep -i nvidia", false, false)
+		"lspci | grep -i vga | grep -i nvidia", false, false)
 	if err != nil {
 		logger.Error("try to find nvidia graphics card error", err)
 		logger.Error("ignore card driver installation")

--- a/pkg/gpu/tasks.go
+++ b/pkg/gpu/tasks.go
@@ -73,6 +73,7 @@ func (t *InstallCudaDeps) Execute(runtime connector.Runtime) error {
 	case systemInfo.IsUbuntu():
 		cudaKeyringVersion = v1alpha2.CudaKeyringVersion1_0
 		if systemInfo.IsUbuntuVersionEqual(connector.Ubuntu24) {
+			cudaKeyringVersion = v1alpha2.CudaKeyringVersion1_1
 			osVersion = "24.04"
 		} else if systemInfo.IsUbuntuVersionEqual(connector.Ubuntu22) {
 			osVersion = "22.04"
@@ -118,8 +119,8 @@ func (t *InstallCudaDriver) Execute(runtime connector.Runtime) error {
 	}
 
 	if runtime.GetSystemInfo().IsDebian() {
-		_, err := runtime.GetRunner().Host.SudoCmd("apt-get -y install nvidia-open-560", false, true)
-		return errors.Wrap(err, "failed to apt-get install nvidia-open-560")
+		_, err := runtime.GetRunner().Host.SudoCmd("apt-get -y install nvidia-open", false, true)
+		return errors.Wrap(err, "failed to apt-get install nvidia-open")
 	}
 
 	if _, err := runtime.GetRunner().Host.SudoCmd("apt-get -y install nvidia-kernel-open-550", false, true); err != nil {
@@ -171,6 +172,11 @@ func (t *UpdateCudaSource) Execute(runtime connector.Runtime) error {
 		return fmt.Errorf("Failed to find %s binary in %s", libnvidia.Filename, libPath)
 	}
 
+	// remove any conflicting libnvidia-container.list
+	_, err = runtime.GetRunner().Host.SudoCmd("rm -rf /etc/apt/sources.list.d/*libnvidia-container.list", false, false)
+	if err != nil {
+		return err
+	}
 	cmd = fmt.Sprintf("cp %s %s", libPath, "/etc/apt/sources.list.d/")
 	if _, err := runtime.GetRunner().Host.SudoCmd(cmd, false, true); err != nil {
 		return err


### PR DESCRIPTION
some native libs on Debian might be conflicting with a hard-coded version of Nvidia driver, so just let the package manager to decide a most appropriate version to install.