### PR TITLE
feat: check the validity of resolv.conf before installation

### DIFF
--- a/pkg/bootstrap/precheck/module.go
+++ b/pkg/bootstrap/precheck/module.go
@@ -84,6 +84,7 @@ func (m *RunPrechecksModule) Init() {
 		new(RequiredPortsCheck),
 		new(ConflictingContainerdCheck),
 		new(CudaChecker),
+		new(ValidResolvConfCheck),
 	}
 	runPreChecks := &task.LocalTask{
 		Name: "RunPrechecks",


### PR DESCRIPTION
add the validity check of `/etc/resolv.conf` and `/run/systemd/resolve/resolv.conf` to the list of prechecks.

if the file specifies a search domain other than `.` or has a syntax error, fail the check.