### PR TITLE
fix: test DNS function properly

### DIFF
--- a/pkg/bootstrap/patch/tasks.go
+++ b/pkg/bootstrap/patch/tasks.go
@@ -301,7 +301,7 @@ func (t *DisableLocalDNSTask) Execute(runtime connector.Runtime) error {
 				return err
 			}
 
-			httpCode, _ := utils.GetHttpStatus("https://download.docker.com/linux/ubuntu")
+			httpCode, _ := utils.GetHttpStatus("https://www.apple.com")
 			if httpCode != 200 {
 				if err := ConfigResolvConf(runtime); err != nil {
 					logger.Errorf("config /etc/resolv.conf error %v", err)


### PR DESCRIPTION
the previous test url of `https://download.docker.com/linux/ubuntu` cannot be reached by cn users, a url that's accessible by both cn and abroad users should be used to just check the normal functioning of the DNS server.