### PR TITLE
fix: pass the new env NVIDIA_CONTAINER_REPO_MIRROR from win to wsl

### DIFF
--- a/pkg/windows/tasks.go
+++ b/pkg/windows/tasks.go
@@ -332,6 +332,7 @@ func (i *InstallTerminus) Execute(runtime connector.Runtime) error {
 		fmt.Sprintf("export %s=%s", common.ENV_HOST_IP, systemInfo.GetLocalIp()),
 		fmt.Sprintf("export %s=%s", common.ENV_DISABLE_HOST_IP_PROMPT, os.Getenv(common.ENV_DISABLE_HOST_IP_PROMPT)),
 		fmt.Sprintf("export %s=%s", common.ENV_DOWNLOAD_CDN_URL, i.KubeConf.Arg.DownloadCdnUrl),
+		fmt.Sprintf("export %s=%s", common.ENV_NVIDIA_CONTAINER_REPO_MIRROR, os.Getenv(common.ENV_NVIDIA_CONTAINER_REPO_MIRROR)),
 	}
 
 	var defaultDomainName = os.Getenv(common.ENV_TERMINUS_OS_DOMAINNAME)


### PR DESCRIPTION
the environment variable added in the https://github.com/beclab/Installer/pull/116 should also be passed through from the Windows installer to the WSL installer.