### PR TITLE
fix: write install phase file before wait for system init

### DIFF
--- a/pkg/phase/cluster/linux.go
+++ b/pkg/phase/cluster/linux.go
@@ -98,6 +98,6 @@ func (l *linuxInstallPhaseBuilder) build() []module.Module {
 		addModule(backupModuleBuilder(func() []module.Module {
 			return l.installBackup()
 		}).withBackup(l.runtime)...).
-		addModule(&terminus.WelcomeModule{}).
-		addModule(&terminus.InstalledModule{})
+		addModule(&terminus.InstalledModule{}).
+		addModule(&terminus.WelcomeModule{})
 }

--- a/pkg/phase/cluster/macos.go
+++ b/pkg/phase/cluster/macos.go
@@ -42,6 +42,6 @@ func (m *macosInstallPhaseBuilder) build() []module.Module {
 	return m.base().
 		addModule(m.installCluster()...).
 		addModule(m.installTerminus()...).
-		addModule(&terminus.WelcomeModule{}).
-		addModule(&terminus.InstalledModule{})
+		addModule(&terminus.InstalledModule{}).
+		addModule(&terminus.WelcomeModule{})
 }


### PR DESCRIPTION
when the `WelcomeModule` is executed, it means all the components of the system have already been installed, we're only waiting for them to initialize, if the wait times out and the installer exits, chances are that the system may still be usable some time later, but the `InstalledModule` is not executed and the `.installed` phase file is not written, which some other tasks depend on, unexpected problems may occur.

therefore, the `InstalledModule` should be executed before the `WelcomeModule`, not after.