### PR TITLE
fix: raise cri timeout to accommodate slow hardwares

### DIFF
--- a/pkg/k3s/tasks.go
+++ b/pkg/k3s/tasks.go
@@ -196,14 +196,15 @@ func (g *GenerateK3sService) Execute(runtime connector.Runtime) error {
 	}
 
 	defaultKubeletArs := map[string]string{
-		"cni-conf-dir":    "/etc/cni/net.d",
-		"cni-bin-dir":     "/opt/cni/bin",
-		"kube-reserved":   "cpu=200m,memory=250Mi,ephemeral-storage=1Gi",
-		"system-reserved": "cpu=200m,memory=250Mi,ephemeral-storage=1Gi",
-		"eviction-hard":   "memory.available<5%,nodefs.available<10%",
-		"config":          "/etc/rancher/k3s/kubelet.config",
-		"containerd":      container.DefaultContainerdCRISocket,
-		"cgroup-driver":   "systemd",
+		"cni-conf-dir":            "/etc/cni/net.d",
+		"cni-bin-dir":             "/opt/cni/bin",
+		"kube-reserved":           "cpu=200m,memory=250Mi,ephemeral-storage=1Gi",
+		"system-reserved":         "cpu=200m,memory=250Mi,ephemeral-storage=1Gi",
+		"eviction-hard":           "memory.available<5%,nodefs.available<10%",
+		"config":                  "/etc/rancher/k3s/kubelet.config",
+		"containerd":              container.DefaultContainerdCRISocket,
+		"cgroup-driver":           "systemd",
+		"runtime-request-timeout": "5m",
 	}
 	defaultKubeProxyArgs := map[string]string{
 		"proxy-mode": "ipvs",

--- a/pkg/kubernetes/templates/v1beta2/kubeadm_config.go
+++ b/pkg/kubernetes/templates/v1beta2/kubeadm_config.go
@@ -285,6 +285,7 @@ func GetKubeletConfiguration(runtime connector.Runtime, kubeConf *common.KubeCon
 		"evictionMaxPodGracePeriod":        120,
 		"evictionPressureTransitionPeriod": "30s",
 		"featureGates":                     FeatureGatesDefaultConfiguration,
+		"runtimeRequestTimeout":            "5m",
 	}
 
 	if securityEnhancement {


### PR DESCRIPTION
the default timeout period of CRI requests is `2m` in kubelet, and can time out during the middle of a normal operation like unpacking a large image on slow hardwares, we explicitly lift it to `5m` to make it more tolerable.