### PR TITLE
fix: switch primary and secondary DNS server for CN user

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -178,6 +178,11 @@ var (
 )
 
 const (
+	OlaresRegistryMirrorHost       = "mirrors.joinolares.cn"
+	OlaresRegistryMirrorHostLegacy = "mirrors.jointerminus.cn"
+)
+
+const (
 	CloudVendorAliYun = "aliyun"
 	CloudVendorAWS    = "aws"
 )


### PR DESCRIPTION
If we need to alter the user's DNS server config during installation, first check if it's a CN user by match the registry mirrors against CN mirrors provided by Olares, and switch the secondary `114.114.114.114` DNS server with the primary `1.1.1.1` DNS server if true. This can help CN users to resolve to nearest CDN rather than the default one.