### PR TITLE
feat: add commands to start/stop Olares components

### DIFF
--- a/cmd/ctl/os/root.go
+++ b/cmd/ctl/os/root.go
@@ -24,6 +24,8 @@ func NewCmdOs() *cobra.Command {
 	rootOsCmd.AddCommand(NewCmdRelease())
 	rootOsCmd.AddCommand(NewCmdPrintInfo())
 	rootOsCmd.AddCommand(NewCmdBackup())
+	rootOsCmd.AddCommand(NewCmdStart())
+	rootOsCmd.AddCommand(NewCmdStop())
 
 	return rootOsCmd
 }

--- a/cmd/ctl/os/startstop.go
+++ b/cmd/ctl/os/startstop.go
@@ -1,0 +1,41 @@
+package os
+
+import (
+	"time"
+
+	"bytetrade.io/web3os/installer/pkg/pipelines"
+	"github.com/spf13/cobra"
+	"log"
+)
+
+func NewCmdStart() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "start",
+		Short: "Start the Olares OS",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := pipelines.StartOlares(); err != nil {
+				log.Fatalf("error: %v", err)
+			}
+		},
+	}
+	return cmd
+}
+
+func NewCmdStop() *cobra.Command {
+	var (
+		timeout       time.Duration
+		checkInterval time.Duration
+	)
+	cmd := &cobra.Command{
+		Use:   "stop",
+		Short: "Stop the Olares OS",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := pipelines.StopOlares(timeout, checkInterval); err != nil {
+				log.Fatalf("error: %v", err)
+			}
+		},
+	}
+	cmd.Flags().DurationVarP(&timeout, "timeout", "t", 1*time.Minute, "Timeout for graceful shutdown before using SIGKILL")
+	cmd.Flags().DurationVarP(&checkInterval, "check-interval", "i", 10*time.Second, "Interval between checks for remaining processes")
+	return cmd
+}

--- a/pkg/bootstrap/os/tasks.go
+++ b/pkg/bootstrap/os/tasks.go
@@ -382,6 +382,8 @@ var (
 	}
 	clusterFiles = []string{
 		"/etc/kubernetes",
+		"/etc/systemd/system/backup-etcd.timer",
+		"/etc/systemd/system/backup-etcd.service",
 		"/etc/systemd/system/etcd.service",
 		"/var/log/calico",
 		"/etc/cni",
@@ -406,13 +408,11 @@ var (
 	}
 
 	networkResetCmds = []string{
-		"iptables -F",
-		"iptables -X",
-		"iptables -F -t nat",
-		"iptables -X -t nat",
+		"ip netns show 2>/dev/null | grep cni- | xargs -r -t -n 1 ip netns delete",
 		"ipvsadm -C",
 		"ip link del kube-ipvs0",
-		"ip link del nodelocaldns",
+		"rm -rf /var/lib/cni",
+		"iptables-save | grep -v KUBE- | grep -v CALICO- | iptables-restore",
 	}
 )
 

--- a/pkg/container/module.go
+++ b/pkg/container/module.go
@@ -393,7 +393,7 @@ func (m *KillContainerdProcessModule) Init() {
 	killContainerdProcess := &task.RemoteTask{
 		Name:     "KillContainerdProcess",
 		Hosts:    m.Runtime.GetHostsByRole(common.Master),
-		Action:   new(KillContainerdProcess),
+		Action:   &KillContainerdProcess{Signal: "KILL"},
 		Parallel: false,
 		Retry:    1,
 	}

--- a/pkg/core/prepare/delay.go
+++ b/pkg/core/prepare/delay.go
@@ -1,0 +1,17 @@
+package prepare
+
+import (
+	"bytetrade.io/web3os/installer/pkg/core/connector"
+	"time"
+)
+
+// InitialDelay is a Prepare implementation that simply wait for Duration amount of time
+type InitialDelay struct {
+	BasePrepare
+	Duration time.Duration
+}
+
+func (p *InitialDelay) PreCheck(runtime connector.Runtime) (bool, error) {
+	time.Sleep(p.Duration)
+	return true, nil
+}

--- a/pkg/pipelines/startstop.go
+++ b/pkg/pipelines/startstop.go
@@ -1,0 +1,51 @@
+package pipelines
+
+import (
+	"time"
+
+	"bytetrade.io/web3os/installer/pkg/common"
+	"bytetrade.io/web3os/installer/pkg/core/module"
+	"bytetrade.io/web3os/installer/pkg/core/pipeline"
+	"bytetrade.io/web3os/installer/pkg/terminus"
+)
+
+func StartOlares() error {
+	arg := common.NewArgument()
+	arg.SetConsoleLog("start.log", true)
+	runtime, err := common.NewKubeRuntime(common.AllInOne, *arg)
+	if err != nil {
+		return err
+	}
+
+	p := &pipeline.Pipeline{
+		Name: "StartOlares",
+		Modules: []module.Module{
+			&terminus.StartOlaresModule{},
+		},
+		Runtime: runtime,
+	}
+
+	return p.Start()
+}
+
+func StopOlares(timeout, checkInterval time.Duration) error {
+	arg := common.NewArgument()
+	arg.SetConsoleLog("stop.log", true)
+	runtime, err := common.NewKubeRuntime(common.AllInOne, *arg)
+	if err != nil {
+		return err
+	}
+
+	p := &pipeline.Pipeline{
+		Name: "StopOlares",
+		Modules: []module.Module{
+			&terminus.StopOlaresModule{
+				Timeout:       timeout,
+				CheckInterval: checkInterval,
+			},
+		},
+		Runtime: runtime,
+	}
+
+	return p.Start()
+}

--- a/pkg/terminus/tasks.go
+++ b/pkg/terminus/tasks.go
@@ -101,6 +101,9 @@ func (t *CheckKeyPodsRunning) Execute(runtime connector.Runtime) error {
 				return fmt.Errorf("pod %s/%s has no container statuses yet", pod.Namespace, pod.Name)
 			}
 			for _, cStatus := range pod.Status.ContainerStatuses {
+				if cStatus.State.Terminated != nil && cStatus.State.Terminated.ExitCode != 0 {
+					return fmt.Errorf("container %s in pod %s/%s is terminated", cStatus.Name, pod.Namespace, pod.Name)
+				}
 				if cStatus.State.Running == nil {
 					return fmt.Errorf("container %s in pod %s/%s is not running", cStatus.Name, pod.Namespace, pod.Name)
 				}


### PR DESCRIPTION
the following commands are added:

- `olares-cli olares stop` to stop components of an installed (or partially installed) Olares.
- `olares-cli olares start` to start components of an installed (or partially installed) and already stopped Olares, and wait for all system pods to be running again.