### PR TITLE
feat: add node graceful shutdown conf

### DIFF
--- a/apis/kubekey/v1alpha2/default.go
+++ b/apis/kubekey/v1alpha2/default.go
@@ -73,40 +73,42 @@ const (
 	DefaultVeleroVersion            = "v1.11.3"
 	DefaultWSLInstallPackageVersion = "2.3.26.0"
 
-	DefaultMaxPods             = 200
-	DefaultPodPidsLimit        = 10000
-	DefaultNodeCidrMaskSize    = 24
-	DefaultIPIPMode            = "Always"
-	DefaultVXLANMode           = "Never"
-	DefaultVethMTU             = 0
-	DefaultBackendMode         = "vxlan"
-	DefaultProxyMode           = "ipvs"
-	DefaultCrioEndpoint        = "unix:///var/run/crio/crio.sock"
-	DefaultContainerdEndpoint  = "unix:///run/containerd/containerd.sock"
-	DefaultIsulaEndpoint       = "unix:///var/run/isulad.sock"
-	Etcd                       = "etcd"
-	Master                     = "master"
-	ControlPlane               = "control-plane"
-	Worker                     = "worker"
-	K8s                        = "k8s"
-	Registry                   = "registry"
-	DefaultEtcdBackupDir       = "/var/backups/kube_etcd"
-	DefaultEtcdBackupPeriod    = 30
-	DefaultKeepBackNumber      = 5
-	DefaultEtcdBackupScriptDir = "/usr/local/bin/kube-scripts"
-	DefaultPodGateway          = "10.233.64.1"
-	DefaultJoinCIDR            = "100.64.0.0/16"
-	DefaultNetworkType         = "geneve"
-	DefaultTunnelType          = "geneve"
-	DefaultPodNicType          = "veth-pair"
-	DefaultModules             = "kube_ovn_fastpath.ko"
-	DefaultRPMs                = "openvswitch-kmod"
-	DefaultVlanID              = "100"
-	DefaultOvnLabel            = "node-role.kubernetes.io/control-plane"
-	DefaultDPDKVersion         = "19.11"
-	DefaultDNSAddress          = "114.114.114.114"
-	DefaultDpdkTunnelIface     = "br-phy"
-	DefaultCNIConfigPriority   = "01"
+	DefaultShutdownGracePeriod             = "30s"
+	DefaultShutdownGracePeriodCriticalPods = "10s"
+	DefaultMaxPods                         = 200
+	DefaultPodPidsLimit                    = 10000
+	DefaultNodeCidrMaskSize                = 24
+	DefaultIPIPMode                        = "Always"
+	DefaultVXLANMode                       = "Never"
+	DefaultVethMTU                         = 0
+	DefaultBackendMode                     = "vxlan"
+	DefaultProxyMode                       = "ipvs"
+	DefaultCrioEndpoint                    = "unix:///var/run/crio/crio.sock"
+	DefaultContainerdEndpoint              = "unix:///run/containerd/containerd.sock"
+	DefaultIsulaEndpoint                   = "unix:///var/run/isulad.sock"
+	Etcd                                   = "etcd"
+	Master                                 = "master"
+	ControlPlane                           = "control-plane"
+	Worker                                 = "worker"
+	K8s                                    = "k8s"
+	Registry                               = "registry"
+	DefaultEtcdBackupDir                   = "/var/backups/kube_etcd"
+	DefaultEtcdBackupPeriod                = 30
+	DefaultKeepBackNumber                  = 5
+	DefaultEtcdBackupScriptDir             = "/usr/local/bin/kube-scripts"
+	DefaultPodGateway                      = "10.233.64.1"
+	DefaultJoinCIDR                        = "100.64.0.0/16"
+	DefaultNetworkType                     = "geneve"
+	DefaultTunnelType                      = "geneve"
+	DefaultPodNicType                      = "veth-pair"
+	DefaultModules                         = "kube_ovn_fastpath.ko"
+	DefaultRPMs                            = "openvswitch-kmod"
+	DefaultVlanID                          = "100"
+	DefaultOvnLabel                        = "node-role.kubernetes.io/control-plane"
+	DefaultDPDKVersion                     = "19.11"
+	DefaultDNSAddress                      = "114.114.114.114"
+	DefaultDpdkTunnelIface                 = "br-phy"
+	DefaultCNIConfigPriority               = "01"
 
 	Docker     = "docker"
 	Containerd = "containerd"
@@ -138,6 +140,12 @@ func (cfg *ClusterSpec) SetDefaultClusterSpec(incluster bool, macos bool) (*Clus
 	}
 	if cfg.Kubernetes.Version == "" {
 		clusterCfg.Kubernetes.Version = DefaultKubeVersion
+	}
+	if cfg.Kubernetes.ShutdownGracePeriod == "" {
+		clusterCfg.Kubernetes.ShutdownGracePeriod = DefaultShutdownGracePeriod
+	}
+	if cfg.Kubernetes.ShutdownGracePeriodCriticalPods == "" {
+		clusterCfg.Kubernetes.ShutdownGracePeriodCriticalPods = DefaultShutdownGracePeriodCriticalPods
 	}
 	if cfg.Kubernetes.MaxPods == 0 {
 		clusterCfg.Kubernetes.MaxPods = DefaultMaxPods

--- a/apis/kubekey/v1alpha2/kubernetes_types.go
+++ b/apis/kubekey/v1alpha2/kubernetes_types.go
@@ -20,18 +20,20 @@ import "k8s.io/apimachinery/pkg/runtime"
 
 // Kubernetes contains the configuration for the cluster
 type Kubernetes struct {
-	Type                   string   `yaml:"type" json:"type,omitempty"`
-	Version                string   `yaml:"version" json:"version,omitempty"`
-	ClusterName            string   `yaml:"clusterName" json:"clusterName,omitempty"`
-	DNSDomain              string   `yaml:"dnsDomain" json:"dnsDomain,omitempty"`
-	DisableKubeProxy       bool     `yaml:"disableKubeProxy" json:"disableKubeProxy,omitempty"`
-	MasqueradeAll          bool     `yaml:"masqueradeAll" json:"masqueradeAll,omitempty"`
-	MaxPods                int      `yaml:"maxPods" json:"maxPods,omitempty"`
-	PodPidsLimit           int      `yaml:"podPidsLimit" json:"podPidsLimit,omitempty"`
-	NodeCidrMaskSize       int      `yaml:"nodeCidrMaskSize" json:"nodeCidrMaskSize,omitempty"`
-	ApiserverCertExtraSans []string `yaml:"apiserverCertExtraSans" json:"apiserverCertExtraSans,omitempty"`
-	ProxyMode              string   `yaml:"proxyMode" json:"proxyMode,omitempty"`
-	AutoRenewCerts         *bool    `yaml:"autoRenewCerts" json:"autoRenewCerts,omitempty"`
+	Type                            string   `yaml:"type" json:"type,omitempty"`
+	Version                         string   `yaml:"version" json:"version,omitempty"`
+	ClusterName                     string   `yaml:"clusterName" json:"clusterName,omitempty"`
+	DNSDomain                       string   `yaml:"dnsDomain" json:"dnsDomain,omitempty"`
+	DisableKubeProxy                bool     `yaml:"disableKubeProxy" json:"disableKubeProxy,omitempty"`
+	MasqueradeAll                   bool     `yaml:"masqueradeAll" json:"masqueradeAll,omitempty"`
+	ShutdownGracePeriod             string   `yaml:"shutdownGracePeriod" json:"shutdownGracePeriod,omitempty"`
+	ShutdownGracePeriodCriticalPods string   `json:"shutdownGracePeriodCriticalPods,omitempty"`
+	MaxPods                         int      `yaml:"maxPods" json:"maxPods,omitempty"`
+	PodPidsLimit                    int      `yaml:"podPidsLimit" json:"podPidsLimit,omitempty"`
+	NodeCidrMaskSize                int      `yaml:"nodeCidrMaskSize" json:"nodeCidrMaskSize,omitempty"`
+	ApiserverCertExtraSans          []string `yaml:"apiserverCertExtraSans" json:"apiserverCertExtraSans,omitempty"`
+	ProxyMode                       string   `yaml:"proxyMode" json:"proxyMode,omitempty"`
+	AutoRenewCerts                  *bool    `yaml:"autoRenewCerts" json:"autoRenewCerts,omitempty"`
 	// +optional
 	Nodelocaldns             *bool                `yaml:"nodelocaldns" json:"nodelocaldns,omitempty"`
 	ContainerManager         string               `yaml:"containerManager" json:"containerManager,omitempty"`

--- a/pkg/k3s/tasks.go
+++ b/pkg/k3s/tasks.go
@@ -255,8 +255,10 @@ func (g *GenerateK3sService) Execute(runtime connector.Runtime) error {
 		Template: templates.K3sKubeletConfig,
 		Dst:      filepath.Join("/etc/rancher/k3s/", templates.K3sKubeletConfig.Name()),
 		Data: util.Data{
-			"MaxPods":       g.KubeConf.Cluster.Kubernetes.MaxPods,
-			"EnablePodSwap": g.KubeConf.Arg.EnablePodSwap,
+			"ShutdownGracePeriod":             g.KubeConf.Cluster.Kubernetes.ShutdownGracePeriod,
+			"ShutdownGracePeriodCriticalPods": g.KubeConf.Cluster.Kubernetes.ShutdownGracePeriodCriticalPods,
+			"MaxPods":                         g.KubeConf.Cluster.Kubernetes.MaxPods,
+			"EnablePodSwap":                   g.KubeConf.Arg.EnablePodSwap,
 		},
 	}
 

--- a/pkg/k3s/templates/k3sService.go
+++ b/pkg/k3s/templates/k3sService.go
@@ -72,6 +72,8 @@ maxPods: {{ .MaxPods }}
 memorySwap:
   swapBehavior: LimitedSwap
 {{- end }}
+shutdownGracePeriod: {{ .ShutdownGracePeriod }}
+shutdownGracePeriodCriticalPods: {{ .ShutdownGracePeriodCriticalPods }}
 		`)))
 
 	// * --kubelet-arg=image-gc-high-threshold=85 --kubelet-arg=image-gc-low-threshold=70

--- a/pkg/kubernetes/templates/v1beta2/kubeadm_config.go
+++ b/pkg/kubernetes/templates/v1beta2/kubeadm_config.go
@@ -276,12 +276,14 @@ func UpdateFeatureGatesConfiguration(args map[string]string, kubeConf *common.Ku
 
 func GetKubeletConfiguration(runtime connector.Runtime, kubeConf *common.KubeConf, criSock string, securityEnhancement bool) map[string]interface{} {
 	defaultKubeletConfiguration := map[string]interface{}{
-		"clusterDomain":      kubeConf.Cluster.Kubernetes.DNSDomain,
-		"clusterDNS":         []string{kubeConf.Cluster.CorednsClusterIP()},
-		"maxPods":            kubeConf.Cluster.Kubernetes.MaxPods,
-		"podPidsLimit":       kubeConf.Cluster.Kubernetes.PodPidsLimit,
-		"rotateCertificates": true,
-		"failSwapOn":         false,
+		"clusterDomain":                   kubeConf.Cluster.Kubernetes.DNSDomain,
+		"clusterDNS":                      []string{kubeConf.Cluster.CorednsClusterIP()},
+		"shutdownGracePeriod":             kubeConf.Cluster.Kubernetes.ShutdownGracePeriod,
+		"shutdownGracePeriodCriticalPods": kubeConf.Cluster.Kubernetes.ShutdownGracePeriodCriticalPods,
+		"maxPods":                         kubeConf.Cluster.Kubernetes.MaxPods,
+		"podPidsLimit":                    kubeConf.Cluster.Kubernetes.PodPidsLimit,
+		"rotateCertificates":              true,
+		"failSwapOn":                      false,
 		"kubeReserved": map[string]string{
 			"cpu":    "200m",
 			"memory": "250Mi",


### PR DESCRIPTION
add a default `shutdownGracePeriod` of `30s` and `shutdownGracePeriodCriticalPods` of `10s` to kubelet config, to enable the node graceful shutdown feature of Kubernetes, and make the shutdown process quicker.