### PR TITLE
feat: lower pod gc threshold

### DIFF
--- a/pkg/k3s/tasks.go
+++ b/pkg/k3s/tasks.go
@@ -210,7 +210,7 @@ func (g *GenerateK3sService) Execute(runtime connector.Runtime) error {
 
 	kubeApiserverArgs, _ := util.GetArgs(map[string]string{}, g.KubeConf.Cluster.Kubernetes.ApiServerArgs)
 	kubeControllerManager, _ := util.GetArgs(map[string]string{
-		"terminated-pod-gc-threshold": "5",
+		"terminated-pod-gc-threshold": "1",
 	}, g.KubeConf.Cluster.Kubernetes.ControllerManagerArgs)
 	kubeSchedulerArgs, _ := util.GetArgs(map[string]string{}, g.KubeConf.Cluster.Kubernetes.SchedulerArgs)
 	kubeletArgs, _ := util.GetArgs(defaultKubeletArs, g.KubeConf.Cluster.Kubernetes.KubeletArgs)

--- a/pkg/kubernetes/templates/v1beta2/kubeadm_config.go
+++ b/pkg/kubernetes/templates/v1beta2/kubeadm_config.go
@@ -183,14 +183,15 @@ var (
 		"tls-cipher-suites":      "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
 	}
 	ControllermanagerArgs = map[string]string{
-		"bind-address":             "0.0.0.0",
-		"cluster-signing-duration": "87600h",
+		"bind-address":                "0.0.0.0",
+		"cluster-signing-duration":    "87600h",
+		"terminated-pod-gc-threshold": "1",
 	}
 	ControllermanagerSecurityArgs = map[string]string{
 		"bind-address":                    "127.0.0.1",
 		"cluster-signing-duration":        "87600h",
 		"profiling":                       "false",
-		"terminated-pod-gc-threshold":     "50",
+		"terminated-pod-gc-threshold":     "1",
 		"use-service-account-credentials": "true",
 	}
 	SchedulerArgs = map[string]string{


### PR DESCRIPTION
set the `terminaged-pod-gc-threshold` option of kube-controller-manager to 1 to trigger automatical garbage collection of terminated pods.

note that the smallest valid value for this option is `1`, so in some cases a terminated pod will still be left not cleaned, the complete garbage collection of terminated pod is discussed in the Kubernetes repo but not merged: https://github.com/kubernetes/enhancements/issues/2890, so maybe in the future we should add a garbage collection controller that cleans up all terminated pods if necessary. 