### PR TITLE
fix: temporarily remove 'i' attribute when chaning ip on WSL

### DIFF
--- a/pkg/bootstrap/precheck/module.go
+++ b/pkg/bootstrap/precheck/module.go
@@ -31,12 +31,12 @@ type RemoveChattrModule struct {
 }
 
 func (m *RemoveChattrModule) Init() {
-	m.Name = "RemoveChattr"
+	m.Name = "RemoveWSLChattr"
 
 	removeChattr := &task.RemoteTask{
-		Name:     "RemoveChattr",
+		Name:     "RemoveWSLChattr",
 		Hosts:    m.Runtime.GetHostsByRole(common.Master),
-		Action:   new(RemoveChattr),
+		Action:   new(RemoveWSLChattr),
 		Parallel: false,
 		Retry:    1,
 	}

--- a/pkg/bootstrap/precheck/tasks.go
+++ b/pkg/bootstrap/precheck/tasks.go
@@ -555,11 +555,26 @@ func (t *GetStorageKeyTask) Execute(runtime connector.Runtime) error {
 	return nil
 }
 
-type RemoveChattr struct {
+type AddWSLChattr struct {
 	common.KubeAction
 }
 
-func (t *RemoveChattr) Execute(runtime connector.Runtime) error {
+func (a *AddWSLChattr) Execute(runtime connector.Runtime) error {
+	if !runtime.GetSystemInfo().IsWsl() {
+		return nil
+	}
+	runtime.GetRunner().SudoCmd("chattr +i /etc/hosts /etc/resolv.conf", false, false)
+	return nil
+}
+
+type RemoveWSLChattr struct {
+	common.KubeAction
+}
+
+func (t *RemoveWSLChattr) Execute(runtime connector.Runtime) error {
+	if !runtime.GetSystemInfo().IsWsl() {
+		return nil
+	}
 	runtime.GetRunner().SudoCmd("chattr -i /etc/hosts", false, true)
 	runtime.GetRunner().SudoCmd("chattr -i /etc/resolv.conf", false, true)
 	return nil

--- a/pkg/terminus/modules.go
+++ b/pkg/terminus/modules.go
@@ -380,6 +380,10 @@ func (m *ChangeIPModule) Init() {
 	}
 	m.Tasks = []task.Interface{
 		&task.LocalTask{
+			Name:   "RemoveFileAttributesForUpdating",
+			Action: new(precheck.RemoveWSLChattr),
+		},
+		&task.LocalTask{
 			Name:   "UpdateHosts",
 			Action: new(UpdateKubeKeyHosts),
 		},
@@ -425,6 +429,11 @@ func (m *ChangeIPModule) Init() {
 				Action: new(SaveMasterHostConfig),
 			})
 	}
+	m.Tasks = append(m.Tasks,
+		&task.LocalTask{
+			Name:   "RewriteFileAttributes",
+			Action: new(precheck.AddWSLChattr),
+		})
 }
 
 func (m *ChangeIPModule) addStorageTasks() {


### PR DESCRIPTION
the 'i' file attribute is set on the `/etc/hosts` file, we need to unset it temporarily in order to update this file during IP changing.