### PR TITLE
fix: pass the correct coredns service ip

### DIFF
--- a/apis/kubekey/v1alpha2/cluster_types.go
+++ b/apis/kubekey/v1alpha2/cluster_types.go
@@ -280,11 +280,6 @@ func toHosts(cfg HostCfg) *KubeHost {
 	return kubeHost
 }
 
-// ClusterIP is used to get the kube-apiserver service address inside the cluster.
-func (cfg *ClusterSpec) ClusterIP() string {
-	return util.ParseIp(cfg.Network.KubeServiceCIDR)[0]
-}
-
 // CorednsClusterIP is used to get the coredns service address inside the cluster.
 func (cfg *ClusterSpec) CorednsClusterIP() string {
 	return util.ParseIp(cfg.Network.KubeServiceCIDR)[2]

--- a/pkg/plugins/dns/module.go
+++ b/pkg/plugins/dns/module.go
@@ -44,7 +44,7 @@ func (c *ClusterDNSModule) Init() {
 	c.Name = "ClusterDNSModule"
 
 	// inject coredns svc ip to the global envs before other relative components are created
-	common.TerminusGlobalEnvs["COREDNS_SVC"] = c.KubeConf.Cluster.ClusterIP()
+	common.TerminusGlobalEnvs["COREDNS_SVC"] = c.KubeConf.Cluster.CorednsClusterIP()
 
 	generateCoreDNDService := &task.RemoteTask{
 		Name:  "GenerateCoreDNSService",


### PR DESCRIPTION
the `ClusterIP()` is not used anymore and should be removed to avoid ambiguity 