### PR TITLE
fix: add MARKET_PROVIDER to global envs

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -327,6 +327,7 @@ var TerminusGlobalEnvs = map[string]interface{}{
 	"TAILSCALE_CONTROLPLANE_URL": "https://controlplane.snowinning.com",
 	"OLARES_ROOT_DIR":            "/olares",
 	ENV_DOWNLOAD_CDN_URL:         cc.DownloadUrl,
+	ENV_MARKET_PROVIDER:          "appstore-server-prod.bttcdn.com",
 }
 
 const (


### PR DESCRIPTION
the app-service needs this value to configure the settings for newly created users.