### PR TITLE
feat: save metadata to and read from release file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/estesp/manifest-tool/v2 v2.1.6
 	github.com/go-playground/validator/v10 v10.22.0
 	github.com/jmoiron/sqlx v1.4.0
+	github.com/joho/godotenv v1.5.1
 	github.com/libp2p/go-netroute v0.2.2
 	github.com/lithammer/dedent v1.1.0
 	github.com/mattn/go-sqlite3 v1.14.22

--- a/go.sum
+++ b/go.sum
@@ -557,6 +557,8 @@ github.com/intel/goresctrl v0.2.0/go.mod h1:+CZdzouYFn5EsxgqAQTEzMfwKwuc0fVdMrT9
 github.com/jmoiron/sqlx v1.4.0 h1:1PLqN7S1UYp5t4SrVVnt4nUVNemrDAtxlulVe+Qgm3o=
 github.com/jmoiron/sqlx v1.4.0/go.mod h1:ZrZ7UsYB/weZdl2Bxg6jCRO9c3YHl8r3ahlKmRT4JLY=
 github.com/joefitzgerald/rainbow-reporter v0.1.0/go.mod h1:481CNgqmVHQZzdIbN52CupLJyoVwB10FQ/IQlF1pdL8=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jonboulle/clockwork v0.2.2 h1:UOGuzwb1PwsrDAObMuhUnj0p5ULPj8V/xJ7Kx9qUBdQ=
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -197,6 +197,7 @@ const (
 	TerminusStateFilePrepared  = ".prepared"
 	TerminusStateFileInstalled = ".installed"
 	MasterHostConfigFile       = "master.conf"
+	OlaresReleaseFile          = "/etc/olares/release"
 )
 
 const (
@@ -274,6 +275,8 @@ const (
 )
 
 const (
+	ENV_OLARES_BASE_DIR              = "OLARES_BASE_DIR"
+	ENV_OLARES_VERSION               = "OLARES_VERSION"
 	ENV_TERMINUS_IS_CLOUD_VERSION    = "TERMINUS_IS_CLOUD_VERSION"
 	ENV_PUBLICLY_ACCESSIBLE          = "PUBLICLY_ACCESSIBLE"
 	ENV_KUBE_TYPE                    = "KUBE_TYPE"

--- a/pkg/common/kube_runtime.go
+++ b/pkg/common/kube_runtime.go
@@ -19,6 +19,7 @@ package common
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/joho/godotenv"
 	"net"
 	"os"
 	"path/filepath"
@@ -53,7 +54,7 @@ type Argument struct {
 	KubernetesVersion   string `json:"kubernetes_version"`
 	KsEnable            bool   `json:"ks_enable"`
 	KsVersion           string `json:"ks_version"`
-	TerminusVersion     string `json:"terminus_version"`
+	OlaresVersion       string `json:"olares_version"`
 	Debug               bool   `json:"debug"`
 	IgnoreErr           bool   `json:"ignore_err"`
 	SkipPullImages      bool   `json:"skip_pull_images"`
@@ -286,7 +287,51 @@ func NewArgument() *Argument {
 	arg.IsCloudInstance, _ = strconv.ParseBool(os.Getenv(ENV_TERMINUS_IS_CLOUD_VERSION))
 	arg.PublicNetworkInfo.PubliclyAccessible, _ = strconv.ParseBool(os.Getenv(ENV_PUBLICLY_ACCESSIBLE))
 	arg.IsOlaresInContainer = os.Getenv("CONTAINER_MODE") == "oic"
+
+	if err := arg.LoadReleaseInfo(); err != nil {
+		fmt.Printf("error loading release info: %v", err)
+		os.Exit(1)
+	}
 	return arg
+}
+
+// LoadReleaseInfo loads base directory and version settings
+// from /etc/olares/release and environment variables,
+// with the latter takes precedence.
+// Note that the command line options --base-dir and --version
+// still have the highest priority and will override any values loaded here
+func (a *Argument) LoadReleaseInfo() error {
+	// load envs from the release file
+	// already existing envs are not overridden so
+	err := godotenv.Load(OlaresReleaseFile)
+
+	// silently ignore the non-existence of a release file
+	// otherwise, return the error
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	a.BaseDir = os.Getenv(ENV_OLARES_BASE_DIR)
+	a.OlaresVersion = os.Getenv(ENV_OLARES_VERSION)
+	return nil
+}
+
+func (a *Argument) SaveReleaseInfo() error {
+	if a.BaseDir == "" {
+		return errors.New("invalid: empty base directory")
+	}
+	if a.OlaresVersion == "" {
+		return errors.New("invalid: empty olares version")
+	}
+	releaseInfoMap := map[string]string{
+		ENV_OLARES_BASE_DIR: a.BaseDir,
+		ENV_OLARES_VERSION:  a.OlaresVersion,
+	}
+	if !util.IsExist(filepath.Dir(OlaresReleaseFile)) {
+		if err := os.MkdirAll(filepath.Dir(OlaresReleaseFile), 0755); err != nil {
+			return fmt.Errorf("failed to create directory %s: %v", filepath.Dir(OlaresReleaseFile), err)
+		}
+	}
+	return godotenv.Write(releaseInfoMap, OlaresReleaseFile)
 }
 
 func (a *Argument) GetWslUserPath() string {
@@ -336,7 +381,7 @@ func (a *Argument) SetGPU(enable bool, share bool) {
 	a.GPU.Share = share
 }
 
-func (a *Argument) SetTerminusVersion(version string) {
+func (a *Argument) SetOlaresVersion(version string) {
 	if version == "" || len(version) <= 2 {
 		return
 	}
@@ -344,7 +389,7 @@ func (a *Argument) SetTerminusVersion(version string) {
 	if version[0] == 'v' {
 		version = version[1:]
 	}
-	a.TerminusVersion = version
+	a.OlaresVersion = version
 }
 
 func (a *Argument) SetRegistryMirrors(registryMirrors string) {
@@ -426,15 +471,20 @@ func (a *Argument) SetKubernetesVersion(kubeType string, kubeVersion string) {
 }
 
 func (a *Argument) SetBaseDir(dir string) {
-	if dir == "" {
-		dir = filepath.Join(a.SystemInfo.GetHomeDir(), common.DefaultBaseDir)
+	if dir != "" {
+		a.BaseDir = dir
 	}
-	a.BaseDir = dir
-	if dir != "" && !filepath.IsAbs(dir) {
-		dir, _ = filepath.Abs(dir)
-		if dir != "" {
-			a.BaseDir = dir
+	if a.BaseDir == "" {
+		a.BaseDir = filepath.Join(a.SystemInfo.GetHomeDir(), common.DefaultBaseDir)
+	}
+	if !filepath.IsAbs(a.BaseDir) {
+		var err error
+		var absBaseDir string
+		absBaseDir, err = filepath.Abs(a.BaseDir)
+		if err != nil {
+			panic(fmt.Errorf("failed to get absolute path for base directory %s: %v", a.BaseDir, err))
 		}
+		a.BaseDir = absBaseDir
 	}
 }
 
@@ -524,7 +574,7 @@ func NewKubeRuntime(flag string, arg Argument) (*KubeRuntime, error) {
 	}
 
 	base := connector.NewBaseRuntime(cluster.Name, connector.NewDialer(),
-		arg.Debug, arg.IgnoreErr, arg.Provider, arg.BaseDir, arg.TerminusVersion, arg.ConsoleLogFileName, arg.ConsoleLogTruncate, arg.SystemInfo)
+		arg.Debug, arg.IgnoreErr, arg.Provider, arg.BaseDir, arg.OlaresVersion, arg.ConsoleLogFileName, arg.ConsoleLogTruncate, arg.SystemInfo)
 
 	clusterSpec := &cluster.Spec
 	defaultCluster, roleGroups := clusterSpec.SetDefaultClusterSpec(arg.InCluster, arg.SystemInfo.IsDarwin())

--- a/pkg/core/connector/runtime.go
+++ b/pkg/core/connector/runtime.go
@@ -47,12 +47,12 @@ type BaseRuntime struct {
 	roleHosts       map[string][]Host
 	deprecatedHosts map[string]string
 	cmdSed          string
-	terminusVersion string
+	olaresVersion   string
 	systemInfo      Systems
 	k8sClient       *kubernetes.Clientset
 }
 
-func NewBaseRuntime(name string, connector Connector, verbose bool, ignoreErr bool, sqlProvider storage.Provider, baseDir string, terminusVersion string, consoleLogFileName string, consoleLogTruncate bool, systemInfo Systems) BaseRuntime {
+func NewBaseRuntime(name string, connector Connector, verbose bool, ignoreErr bool, sqlProvider storage.Provider, baseDir string, olaresVersion string, consoleLogFileName string, consoleLogTruncate bool, systemInfo Systems) BaseRuntime {
 	base := BaseRuntime{
 		ObjName:         name,
 		connector:       connector,
@@ -64,7 +64,7 @@ func NewBaseRuntime(name string, connector Connector, verbose bool, ignoreErr bo
 		deprecatedHosts: make(map[string]string),
 		cmdSed:          util.FormatSed(systemInfo.IsDarwin()),
 		systemInfo:      systemInfo,
-		terminusVersion: terminusVersion,
+		olaresVersion:   olaresVersion,
 	}
 
 	if systemInfo.IsWindows() {
@@ -139,7 +139,7 @@ func (b *BaseRuntime) GenerateBaseDir(baseDir string) error {
 }
 
 func (b *BaseRuntime) GenerateWorkDir() error {
-	installerPath := filepath.Join(b.baseDir, "versions", fmt.Sprintf("v%s", b.terminusVersion))
+	installerPath := filepath.Join(b.baseDir, "versions", fmt.Sprintf("v%s", b.olaresVersion))
 	if err := util.CreateDir(installerPath); err != nil {
 		return errors.Wrap(err, "create wizard dir failed")
 	}

--- a/pkg/daemon/task.go
+++ b/pkg/daemon/task.go
@@ -55,7 +55,7 @@ func (g *GenerateTerminusdServiceEnv) Execute(runtime connector.Runtime) error {
 		Template: templates.TerminusdEnv,
 		Dst:      filepath.Join("/etc/systemd/system/", templates.TerminusdEnv.Name()),
 		Data: util.Data{
-			"Version":                g.KubeConf.Arg.TerminusVersion,
+			"Version":                g.KubeConf.Arg.OlaresVersion,
 			"KubeType":               g.KubeConf.Arg.Kubetype,
 			"RegistryMirrors":        g.KubeConf.Arg.RegistryMirrors,
 			"BaseDir":                baseDir,

--- a/pkg/phase/cluster/delete_cluster.go
+++ b/pkg/phase/cluster/delete_cluster.go
@@ -132,6 +132,7 @@ func (p *phaseBuilder) phasePrepare() *phaseBuilder {
 				PhaseFile: common.TerminusStateFilePrepared,
 				BaseDir:   p.runtime.GetBaseDir(),
 			},
+			&terminus.RemoveReleaseFileModule{},
 		)
 	}
 	return p
@@ -173,7 +174,7 @@ func (p *phaseBuilder) phaseMacos() {
 	}
 }
 
-func UninstallTerminus(phase string, args *common.Argument, runtime *common.KubeRuntime) pipeline.Pipeline {
+func UninstallTerminus(phase string, runtime *common.KubeRuntime) pipeline.Pipeline {
 	var builder = &phaseBuilder{
 		phase:   phase,
 		runtime: runtime,

--- a/pkg/phase/download/download_wizard.go
+++ b/pkg/phase/download/download_wizard.go
@@ -12,7 +12,7 @@ func NewDownloadWizard(runtime *common.KubeRuntime) *pipeline.Pipeline {
 
 	m := []module.Module{
 		&precheck.GreetingsModule{},
-		&terminus.InstallWizardDownloadModule{Version: runtime.Arg.TerminusVersion, DownloadCdnUrl: runtime.Arg.DownloadCdnUrl},
+		&terminus.InstallWizardDownloadModule{Version: runtime.Arg.OlaresVersion, DownloadCdnUrl: runtime.Arg.DownloadCdnUrl},
 	}
 
 	return &pipeline.Pipeline{

--- a/pkg/phase/root.go
+++ b/pkg/phase/root.go
@@ -5,8 +5,8 @@ import (
 	"bytetrade.io/web3os/installer/pkg/terminus"
 )
 
-func GetTerminusVersion() (string, error) {
-	var terminusTask = &terminus.GetTerminusVersion{}
+func GetOlaresVersion() (string, error) {
+	var terminusTask = &terminus.GetOlaresVersion{}
 	return terminusTask.Execute()
 }
 

--- a/pkg/phase/system/linux.go
+++ b/pkg/phase/system/linux.go
@@ -117,5 +117,6 @@ func (l *linuxPhaseBuilder) build() []module.Module {
 				},
 			}
 		}).inBox(l.runtime)...).
-		addModule(&terminus.PreparedModule{})
+		addModule(&terminus.PreparedModule{}).
+		addModule(&terminus.WriteReleaseFileModule{})
 }

--- a/pkg/phase/system/wsl.go
+++ b/pkg/phase/system/wsl.go
@@ -116,5 +116,6 @@ func (l *wslPhaseBuilder) build() []module.Module {
 				},
 			}
 		}).inBox(l.runtime)...).
-		addModule(&terminus.PreparedModule{})
+		addModule(&terminus.PreparedModule{}).
+		addModule(&terminus.WriteReleaseFileModule{})
 }

--- a/pkg/pipelines/add_node.go
+++ b/pkg/pipelines/add_node.go
@@ -20,7 +20,7 @@ func AddNodePipeline(opts *options.AddNodeOptions) error {
 	if opts.Version == "" {
 		return errors.New("Olares version must be specified")
 	}
-	arg.SetTerminusVersion(opts.Version)
+	arg.SetOlaresVersion(opts.Version)
 	if err := arg.LoadMasterHostConfigIfAny(); err != nil {
 		return errors.Wrap(err, "failed to load master host config")
 	}

--- a/pkg/pipelines/changeip.go
+++ b/pkg/pipelines/changeip.go
@@ -16,11 +16,11 @@ func ChangeIPPipeline(opt *options.ChangeIPOptions) error {
 	terminusVersion := opt.Version
 	kubeType := phase.GetKubeType()
 	if terminusVersion == "" {
-		terminusVersion, _ = phase.GetTerminusVersion()
+		terminusVersion, _ = phase.GetOlaresVersion()
 	}
 
 	var arg = common.NewArgument()
-	arg.SetTerminusVersion(terminusVersion)
+	arg.SetOlaresVersion(terminusVersion)
 	arg.SetBaseDir(opt.BaseDir)
 	arg.SetConsoleLog("changeip.log", true)
 	arg.SetKubeVersion(kubeType)

--- a/pkg/pipelines/check_download.go
+++ b/pkg/pipelines/check_download.go
@@ -10,7 +10,7 @@ import (
 
 func CheckDownloadInstallationPackage(opts *options.CliDownloadOptions) error {
 	arg := common.NewArgument()
-	arg.SetTerminusVersion(opts.Version)
+	arg.SetOlaresVersion(opts.Version)
 	arg.SetBaseDir(opts.BaseDir)
 
 	runtime, err := common.NewKubeRuntime(common.AllInOne, *arg)

--- a/pkg/pipelines/download_package.go
+++ b/pkg/pipelines/download_package.go
@@ -15,7 +15,7 @@ func DownloadInstallationPackage(opts *options.CliDownloadOptions) error {
 	arg := common.NewArgument()
 	arg.SetBaseDir(opts.BaseDir)
 	arg.SetKubeVersion(opts.KubeType)
-	arg.SetTerminusVersion(opts.Version)
+	arg.SetOlaresVersion(opts.Version)
 	arg.SetDownloadCdnUrl(opts.DownloadCdnUrl)
 
 	runtime, err := common.NewKubeRuntime(common.AllInOne, *arg)

--- a/pkg/pipelines/download_wizard.go
+++ b/pkg/pipelines/download_wizard.go
@@ -13,7 +13,7 @@ import (
 func DownloadInstallationWizard(opts *options.CliDownloadWizardOptions) error {
 	arg := common.NewArgument()
 	arg.SetKubeVersion(opts.KubeType)
-	arg.SetTerminusVersion(opts.Version)
+	arg.SetOlaresVersion(opts.Version)
 	arg.SetBaseDir(opts.BaseDir)
 	arg.SetDownloadCdnUrl(opts.DownloadCdnUrl)
 

--- a/pkg/pipelines/gpu_install.go
+++ b/pkg/pipelines/gpu_install.go
@@ -14,7 +14,7 @@ import (
 
 func InstallGpuDrivers(opt *options.InstallGpuOptions) error {
 	arg := common.NewArgument()
-	arg.SetTerminusVersion(opt.Version)
+	arg.SetOlaresVersion(opt.Version)
 	arg.SetCudaVersion(opt.Cuda)
 	arg.SetBaseDir(opt.BaseDir)
 	arg.SetConsoleLog("gpuinstall.log", true)

--- a/pkg/pipelines/info_terminus.go
+++ b/pkg/pipelines/info_terminus.go
@@ -7,7 +7,7 @@ import (
 )
 
 func PrintTerminusInfo() {
-	var cli = &terminus.GetTerminusVersion{}
+	var cli = &terminus.GetOlaresVersion{}
 	terminusVersion, err := cli.Execute()
 	if err != nil {
 		fmt.Printf("Olares: not installed\n")

--- a/pkg/pipelines/install_terminus.go
+++ b/pkg/pipelines/install_terminus.go
@@ -17,7 +17,7 @@ import (
 )
 
 func CliInstallTerminusPipeline(opts *options.CliTerminusInstallOptions) error {
-	var terminusVersion, _ = phase.GetTerminusVersion()
+	var terminusVersion, _ = phase.GetOlaresVersion()
 	if terminusVersion != "" {
 		return errors.New("Olares is already installed, please uninstall it first.")
 	}
@@ -25,7 +25,7 @@ func CliInstallTerminusPipeline(opts *options.CliTerminusInstallOptions) error {
 	arg := common.NewArgument()
 	arg.SetBaseDir(opts.BaseDir)
 	arg.SetKubeVersion(opts.KubeType)
-	arg.SetTerminusVersion(opts.Version)
+	arg.SetOlaresVersion(opts.Version)
 	arg.SetMinikubeProfile(opts.MiniKubeProfile)
 	arg.SetStorage(getStorageValueFromEnv())
 	arg.SetReverseProxy()

--- a/pkg/pipelines/precheck.go
+++ b/pkg/pipelines/precheck.go
@@ -12,7 +12,7 @@ func StartPreCheckPipeline(opt *options.PreCheckOptions) error {
 	terminusVersion := opt.Version
 
 	var arg = common.NewArgument()
-	arg.SetTerminusVersion(terminusVersion)
+	arg.SetOlaresVersion(terminusVersion)
 	arg.SetBaseDir(opt.BaseDir)
 	arg.SetConsoleLog("precheck.log", true)
 

--- a/pkg/pipelines/prepare_system.go
+++ b/pkg/pipelines/prepare_system.go
@@ -14,7 +14,7 @@ import (
 
 func PrepareSystemPipeline(opts *options.CliPrepareSystemOptions) error {
 
-	var terminusVersion, _ = phase.GetTerminusVersion()
+	var terminusVersion, _ = phase.GetOlaresVersion()
 	if terminusVersion != "" {
 		return errors.New("Olares is already installed, please uninstall it first.")
 	}
@@ -23,7 +23,7 @@ func PrepareSystemPipeline(opts *options.CliPrepareSystemOptions) error {
 	arg.SetBaseDir(opts.BaseDir)
 	arg.SetKubeVersion(opts.KubeType)
 	arg.SetMinikubeProfile(opts.MinikubeProfile)
-	arg.SetTerminusVersion(opts.Version)
+	arg.SetOlaresVersion(opts.Version)
 	arg.SetRegistryMirrors(opts.RegistryMirrors)
 	arg.SetStorage(getStorageValueFromEnv())
 	arg.SetTokenMaxAge()

--- a/pkg/pipelines/storage.go
+++ b/pkg/pipelines/storage.go
@@ -11,14 +11,14 @@ import (
 )
 
 func CliInstallStoragePipeline(opts *options.InstallStorageOptions) error {
-	var terminusVersion, _ = phase.GetTerminusVersion()
+	var terminusVersion, _ = phase.GetOlaresVersion()
 	if terminusVersion != "" {
 		return errors.New("Olares is already installed, please uninstall it first.")
 	}
 
 	arg := common.NewArgument()
 	arg.SetBaseDir(opts.BaseDir)
-	arg.SetTerminusVersion(opts.Version)
+	arg.SetOlaresVersion(opts.Version)
 	arg.SetStorage(getStorageValueFromEnv())
 
 	runtime, err := common.NewKubeRuntime(common.AllInOne, *arg)

--- a/pkg/pipelines/uninstall_terminus.go
+++ b/pkg/pipelines/uninstall_terminus.go
@@ -16,11 +16,11 @@ func UninstallTerminusPipeline(opt *options.CliTerminusUninstallOptions) error {
 	kubeType := phase.GetKubeType()
 
 	if terminusVersion == "" {
-		terminusVersion, _ = phase.GetTerminusVersion()
+		terminusVersion, _ = phase.GetOlaresVersion()
 	}
 
 	var arg = common.NewArgument()
-	arg.SetTerminusVersion(terminusVersion)
+	arg.SetOlaresVersion(terminusVersion)
 	arg.SetBaseDir(opt.BaseDir)
 	arg.SetConsoleLog("uninstall.log", true)
 	arg.SetKubeVersion(kubeType)
@@ -45,7 +45,7 @@ func UninstallTerminusPipeline(opt *options.CliTerminusUninstallOptions) error {
 		phaseName = cluster.PhaseDownload.String()
 	}
 
-	var p = cluster.UninstallTerminus(phaseName, arg, runtime)
+	var p = cluster.UninstallTerminus(phaseName, runtime)
 	if err := p.Start(); err != nil {
 		logger.Errorf("uninstall Olares failed: %v", err)
 		return err

--- a/pkg/terminus/modules.go
+++ b/pkg/terminus/modules.go
@@ -67,6 +67,36 @@ func (m *PreparedModule) Init() {
 	}
 }
 
+type WriteReleaseFileModule struct {
+	common.KubeModule
+}
+
+func (m *WriteReleaseFileModule) Init() {
+	m.Name = "WriteReleaseFile"
+
+	m.Tasks = []task.Interface{
+		&task.LocalTask{
+			Name:   "WriteReleaseFile",
+			Action: new(WriteReleaseFile),
+		},
+	}
+}
+
+type RemoveReleaseFileModule struct {
+	common.KubeModule
+}
+
+func (m *RemoveReleaseFileModule) Init() {
+	m.Name = "RemoveReleaseFile"
+
+	m.Tasks = []task.Interface{
+		&task.LocalTask{
+			Name:   "RemoveReleaseFile",
+			Action: new(RemoveReleaseFile),
+		},
+	}
+}
+
 type CheckPreparedModule struct {
 	common.KubeModule
 	Force bool

--- a/pkg/windows/tasks.go
+++ b/pkg/windows/tasks.go
@@ -524,8 +524,8 @@ func (i *InstallTerminus) Execute(runtime connector.Runtime) error {
 		downloadUrl = cc.DownloadUrl
 	}
 	var installScript = fmt.Sprintf("curl -fsSL %s | bash -", bashUrl)
-	if i.KubeConf.Arg.TerminusVersion != "" {
-		var installFile = fmt.Sprintf("install-wizard-v%s.tar.gz", i.KubeConf.Arg.TerminusVersion)
+	if i.KubeConf.Arg.OlaresVersion != "" {
+		var installFile = fmt.Sprintf("install-wizard-v%s.tar.gz", i.KubeConf.Arg.OlaresVersion)
 		installScript = fmt.Sprintf("curl -fsSLO %s/%s && tar -xf %s -C ./ ./install.sh && rm -rf %s && bash ./install.sh",
 			downloadUrl, installFile, installFile, installFile)
 	}


### PR DESCRIPTION
Save the metadata value of `basedir` and `version` in the `/etc/olares/release` file with a dot env format, like the `/etc/os-release` file, e.g.:
```
~ cat /etc/olares/release
OLARES_BASE_DIR="/home/keven/.olares"
OLARES_VERSION="1.12.0-20250408"
```
And the config is loaded from the following sources, with each source overriding the previous:
- /etc/olares/release
- environment variables, i.e., `OLARES_BASE_DIR`, `OLARES_VERSION` 
- command line options, i.e., `--base-dir/-b`, `--version/-v`
In the absence of the release file, or when the command line options are explicitly specified, the current behavior is retained.

The release file is saved when the `prepare` phase is finished, thus enabling multiple execution of`olares-cli olares uninstall` and `olares-cli olares install` without the need of command line options, the same with other commands like `olares-cli gpu install` and `olares-cli olares change-ip`.

Effectively, the `/usr/local/bin/olares-uninstall.sh` can be removed now, but what other components have dependency on it is unknown, so I'll leave it after that's been clarified.