### PR TITLE
fix: clear ip6tables and ipset data during uninstall

### DIFF
--- a/pkg/bootstrap/os/tasks.go
+++ b/pkg/bootstrap/os/tasks.go
@@ -413,6 +413,8 @@ var (
 		"ip link del kube-ipvs0",
 		"rm -rf /var/lib/cni",
 		"iptables-save | grep -v KUBE- | grep -v CALICO- | iptables-restore",
+		"ip6tables-save | grep -v KUBE- | grep -v CALICO- | ip6tables-restore",
+		"ipset x",
 	}
 )
 

--- a/pkg/bootstrap/patch/tasks.go
+++ b/pkg/bootstrap/patch/tasks.go
@@ -53,6 +53,12 @@ func (t *PatchTask) Execute(runtime connector.Runtime) error {
 	if _, err := util.GetCommand(common.CommandIptables); err != nil {
 		pre_reqs = pre_reqs + " iptables "
 	}
+	if _, err := util.GetCommand(common.CommandIp6tables); err != nil {
+		pre_reqs = pre_reqs + " iptables "
+	}
+	if _, err := util.GetCommand(common.CommandIpset); err != nil {
+		pre_reqs = pre_reqs + " ipset "
+	}
 	if _, err := util.GetCommand(common.CommandNmcli); err != nil {
 		pre_reqs = pre_reqs + " network-manager "
 	}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -200,7 +200,9 @@ const (
 )
 
 const (
+	CommandIpset        = "ipset"
 	CommandIptables     = "iptables"
+	CommandIp6tables    = "ip6tables"
 	CommandGPG          = "gpg"
 	CommandSudo         = "sudo"
 	CommandSocat        = "socat"

--- a/pkg/phase/cluster/delete_cluster.go
+++ b/pkg/phase/cluster/delete_cluster.go
@@ -99,9 +99,9 @@ func (p *phaseBuilder) phaseInstall() *phaseBuilder {
 		}
 
 		p.modules = append(p.modules,
-			&os.ClearOSEnvironmentModule{},
 			&certs.UninstallAutoRenewCertsModule{},
 			&container.KillContainerdProcessModule{},
+			&os.ClearOSEnvironmentModule{},
 			&certs.UninstallCertsFilesModule{},
 			&storage.DeleteUserDataModule{},
 			&terminus.DeleteWizardFilesModule{},


### PR DESCRIPTION
Multiple reinstallation of Kubernetes might introduce some conflicts, especially across different versions.

In this specific case, the ipset sets and ip6tables rules managed by a v1.32 kube-proxy instance were left not cleaned even after a total uninstallation, and the ipset sets with a new revision has resulted in the calico of an older version refusing to start.

![image](https://github.com/user-attachments/assets/e24baa40-7eac-4546-b52c-8e8b784dc38a)

Two simple commands are added in this PR to clear these data during installation.

Note that a ipset set referenced by any iptables rules can only be deleted after the rules are gone.
![image](https://github.com/user-attachments/assets/739d5a03-0b4d-43cf-aa14-6ce0b33afa35)
