### PR TITLE
fix: backups-sdk up to 0.1.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.22.4
 
 replace (
-	bytetrade.io/web3os/backups-sdk => github.com/Above-Os/backups-sdk v0.1.2
+	bytetrade.io/web3os/backups-sdk => github.com/Above-Os/backups-sdk v0.1.11
 	github.com/chai2010/gettext-go => github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5
 	github.com/containerd/containerd => github.com/containerd/containerd v1.6.6
 	github.com/containers/image/v5 => github.com/containers/image/v5 v5.21.1

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/14rcole/gopopulate v0.0.0-20180821133914-b175b219e774/go.mod h1:6/0dYRLLXyJjbkIPeeGyoJ/eKOSI0eU6eTlCBYibgd0=
-github.com/Above-Os/backups-sdk v0.1.2 h1:16TH/kYhLPebJEQF7/jSdxZyw7Z8nmQX0u/IC6nveRA=
-github.com/Above-Os/backups-sdk v0.1.2/go.mod h1:lHKxPobrxTcR9iGR67Hiry7Y91GboHxmkey4z72Knzk=
+github.com/Above-Os/backups-sdk v0.1.11 h1:eGkfPBP/vTmMX26ZFjNDiKitUXEGhYtNEgDb82lEXf0=
+github.com/Above-Os/backups-sdk v0.1.11/go.mod h1:fT7a5J8LwaA2SuWLFEMj0FdK8E57BQYFc76c7JwGTRg=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20210715213245-6c3934b029d8/go.mod h1:CzsSbkDixRphAF5hS6wbMKq0eI6ccJRb7/A0M6JBnwg=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=


### PR DESCRIPTION
**Background**
feat: backups-sdk up to 0.1.11
fix: concurrent access errors in scanner

**PRs**
https://github.com/Above-Os/backups-sdk/pull/17