### PR TITLE
feat: add command to upgrade GPU driver

### DIFF
--- a/cmd/ctl/gpu/root.go
+++ b/cmd/ctl/gpu/root.go
@@ -14,6 +14,7 @@ func NewCmdGpu() *cobra.Command {
 	rootGpuCmd.AddCommand(NewCmdUninstallpu())
 	rootGpuCmd.AddCommand(NewCmdEnableGpu())
 	rootGpuCmd.AddCommand(NewCmdDisableGpu())
+	rootGpuCmd.AddCommand(NewCmdUpgradeGpu())
 	rootGpuCmd.AddCommand(NewCmdGpuStatus())
 	return rootGpuCmd
 }

--- a/cmd/ctl/gpu/upgrade.go
+++ b/cmd/ctl/gpu/upgrade.go
@@ -1,0 +1,24 @@
+package gpu
+
+import (
+	"log"
+
+	"bytetrade.io/web3os/installer/cmd/ctl/options"
+	"bytetrade.io/web3os/installer/pkg/pipelines"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdUpgradeGpu() *cobra.Command {
+	o := options.NewInstallGpuOptions()
+	cmd := &cobra.Command{
+		Use:   "upgrade",
+		Short: "upgrade GPU drivers for Olares",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := pipelines.UpgradeGpuDrivers(o); err != nil {
+				log.Fatalf("error: %v", err)
+			}
+		},
+	}
+	o.AddFlags(cmd)
+	return cmd
+}

--- a/pkg/bootstrap/precheck/tasks.go
+++ b/pkg/bootstrap/precheck/tasks.go
@@ -582,7 +582,7 @@ func (t *RemoveWSLChattr) Execute(runtime connector.Runtime) error {
 
 var ErrUnsupportedCudaVersion = errors.New("cuda version is too old, please install at least version 12.4, or you can uninstall it, REBOOT your machine, and let Olares install a new version for you.")
 var ErrCudaInstalled = errors.New("cuda is installed")
-var supportedCudaVersions = []string{"12.4", "12.5", "12.6", "12.7"}
+var supportedCudaVersions = []string{"12.4", "12.5", "12.6", "12.7", "12.8"}
 
 // CudaCheckTask checks the cuda version, if the current version is not supported, it will return an error
 // before executing the command `olares-cli gpu install`, we need to check the cuda version

--- a/pkg/pipelines/gpu_upgrade.go
+++ b/pkg/pipelines/gpu_upgrade.go
@@ -1,0 +1,99 @@
+package pipelines
+
+import (
+	"bytetrade.io/web3os/installer/cmd/ctl/options"
+	"bytetrade.io/web3os/installer/pkg/common"
+	"bytetrade.io/web3os/installer/pkg/core/logger"
+	"bytetrade.io/web3os/installer/pkg/core/module"
+	"bytetrade.io/web3os/installer/pkg/core/pipeline"
+	"bytetrade.io/web3os/installer/pkg/gpu"
+	"bytetrade.io/web3os/installer/pkg/manifest"
+	"bytetrade.io/web3os/installer/pkg/utils"
+	"fmt"
+	"io"
+	"os/exec"
+	"path"
+	"strings"
+)
+
+func UpgradeGpuDrivers(opt *options.InstallGpuOptions) error {
+	arg := common.NewArgument()
+	arg.SetOlaresVersion(opt.Version)
+	arg.SetCudaVersion(opt.Cuda)
+	arg.SetBaseDir(opt.BaseDir)
+	arg.SetConsoleLog("gpuupgrade.log", true)
+	runtime, err := common.NewKubeRuntime(common.AllInOne, *arg)
+	if err != nil {
+		return err
+	}
+
+	manifestFile := path.Join(runtime.GetInstallerDir(), "installation.manifest")
+
+	runtime.Arg.SetManifest(manifestFile)
+
+	manifestMap, err := manifest.ReadAll(runtime.Arg.Manifest)
+	if err != nil {
+		logger.Fatal(err)
+	}
+
+	p := &pipeline.Pipeline{
+		Name: "UpgradeGpuDrivers",
+		Modules: []module.Module{
+			&gpu.ExitIfNoDriverUpgradeNeededModule{},
+			&gpu.UninstallCudaModule{},
+			&gpu.InstallDriversModule{
+				ManifestModule: manifest.ManifestModule{
+					Manifest: manifestMap,
+					BaseDir:  runtime.Arg.BaseDir,
+				},
+			},
+			&gpu.InstallContainerToolkitModule{
+				ManifestModule: manifest.ManifestModule{
+					Manifest: manifestMap,
+					BaseDir:  runtime.Arg.BaseDir,
+				},
+				// when nvidia driver is just upgraded
+				// nvidia-smi will fail to execute
+				SkipCudaCheck: true,
+			},
+			&gpu.RestartContainerdModule{},
+		},
+		Runtime: runtime,
+	}
+
+	if err := p.Start(); err != nil {
+		return err
+	}
+
+	fmt.Println()
+	fmt.Println("The GPU driver has been upgraded, for it to work properly, the machine needs to be rebooted.")
+	reader, err := utils.GetBufIOReaderOfTerminalInput()
+	if err != nil {
+		return nil
+	}
+	for {
+		fmt.Printf("Reboot now? [yes/no]: ")
+		input, err := reader.ReadString('\n')
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return fmt.Errorf("failed to read user input for reboot confirmation: %v", err)
+		}
+		input = strings.ToLower(strings.TrimSpace(input))
+		if input == "" {
+			continue
+		}
+		if strings.HasPrefix("yes", input) {
+			output, err := exec.Command("reboot").CombinedOutput()
+			if err != nil {
+				return fmt.Errorf("failed to reboot: %v", err)
+			}
+			fmt.Println(string(output))
+			return nil
+		} else if strings.HasPrefix("no", input) {
+			return nil
+		}
+	}
+
+}

--- a/pkg/terminus/tasks.go
+++ b/pkg/terminus/tasks.go
@@ -250,7 +250,11 @@ type RemoveReleaseFile struct {
 }
 
 func (t *RemoveReleaseFile) Execute(runtime connector.Runtime) error {
-	return os.Remove(common.OlaresReleaseFile)
+	err := os.Remove(common.OlaresReleaseFile)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
 }
 
 type CheckPrepared struct {


### PR DESCRIPTION
- Change the default GPU driver during installation to 570 (CUDA version: 12.8)
- Add a new command `olares-cli gpu upgrade` to upgrade an older GPU driver to the current version.