### PR TITLE
feat: make installation idempotent using helm upgrade

### DIFF
--- a/pkg/kubesphere/plugins/kscore.go
+++ b/pkg/kubesphere/plugins/kscore.go
@@ -57,8 +57,8 @@ func (t *CreateKsCore) Execute(runtime connector.Runtime) error {
 		"Namespace":    common.NamespaceKubesphereSystem,
 		"ReplicaCount": fmt.Sprintf("%d", masterNum),
 	}
-	if err := utils.InstallCharts(context.Background(), actionConfig, settings, appKsCoreName,
-		appPath, "", common.NamespaceKubesphereSystem, values); err != nil {
+	if err := utils.UpgradeCharts(context.Background(), actionConfig, settings, appKsCoreName,
+		appPath, "", common.NamespaceKubesphereSystem, values, false); err != nil {
 		logger.Errorf("failed to install %s chart: %v", appKsCoreName, err)
 		return err
 	}

--- a/pkg/kubesphere/plugins/kscore_config.go
+++ b/pkg/kubesphere/plugins/kscore_config.go
@@ -221,8 +221,8 @@ func (t *CreateKsCoreConfig) Execute(runtime connector.Runtime) error {
 	values["Release"] = map[string]string{
 		"Namespace": common.NamespaceKubesphereSystem,
 	}
-	if err := utils.InstallCharts(context.Background(), actionConfig, settings, appKsCoreConfigName,
-		appPath, "", common.NamespaceKubesphereSystem, values); err != nil {
+	if err := utils.UpgradeCharts(context.Background(), actionConfig, settings, appKsCoreConfigName,
+		appPath, "", common.NamespaceKubesphereSystem, values, false); err != nil {
 		logger.Errorf("failed to install %s chart: %v", appKsCoreConfigName, err)
 		return err
 	}
@@ -235,8 +235,8 @@ func (t *CreateKsCoreConfig) Execute(runtime connector.Runtime) error {
 		"JwtSecret":   jwtSecretIf.(string),
 		"TokenMaxAge": t.KubeConf.Arg.TokenMaxAge * int64(time.Second),
 	}
-	if err := utils.InstallCharts(context.Background(), actionConfig, settings, appKsConfigName,
-		appPath, "", common.NamespaceKubesphereSystem, values); err != nil {
+	if err := utils.UpgradeCharts(context.Background(), actionConfig, settings, appKsConfigName,
+		appPath, "", common.NamespaceKubesphereSystem, values, false); err != nil {
 		logger.Errorf("failed to install %s chart: %v", appKsConfigName, err)
 		return err
 	}

--- a/pkg/kubesphere/plugins/monitor_notification.go
+++ b/pkg/kubesphere/plugins/monitor_notification.go
@@ -54,7 +54,7 @@ func (t *CreateMonitorNotification) Execute(runtime connector.Runtime) error {
 		"Replicas":  fmt.Sprintf("%d", replicas),
 	}
 
-	if err := utils.InstallCharts(ctx, actionConfig, settings, appName, appPath, "", common.NamespaceKubesphereMonitoringSystem, values); err != nil {
+	if err := utils.UpgradeCharts(ctx, actionConfig, settings, appName, appPath, "", common.NamespaceKubesphereMonitoringSystem, values, false); err != nil {
 		return err
 	}
 

--- a/pkg/kubesphere/plugins/redis.go
+++ b/pkg/kubesphere/plugins/redis.go
@@ -108,7 +108,7 @@ func (t *DeployRedis) Execute(runtime connector.Runtime) error {
 	var ctx, cancel = context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancel()
 
-	if err := utils.InstallCharts(ctx, actionConfig, settings, appName, appPath, "", common.NamespaceKubesphereSystem, nil); err != nil {
+	if err := utils.UpgradeCharts(ctx, actionConfig, settings, appName, appPath, "", common.NamespaceKubesphereSystem, nil, false); err != nil {
 		return err
 	}
 

--- a/pkg/kubesphere/plugins/snapshotcontroller.go
+++ b/pkg/kubesphere/plugins/snapshotcontroller.go
@@ -56,8 +56,8 @@ func (t *DeploySnapshotController) Execute(runtime connector.Runtime) error {
 		"Namespace": common.NamespaceKubeSystem,
 	}
 
-	if err := utils.InstallCharts(ctx, actionConfig, settings, appName, appPath, "",
-		common.NamespaceKubeSystem, values); err != nil {
+	if err := utils.UpgradeCharts(ctx, actionConfig, settings, appName, appPath, "",
+		common.NamespaceKubeSystem, values, false); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Change all the current installation of charts from `Install` to `Upgrade` to make them idempotent.