### PR TITLE
feat: upgrade cuda version and optimize gpu driver install logic

### DIFF
--- a/cmd/ctl/options/gpu_options.go
+++ b/cmd/ctl/options/gpu_options.go
@@ -1,7 +1,9 @@
 package options
 
 import (
+	"bytetrade.io/web3os/installer/pkg/common"
 	cc "bytetrade.io/web3os/installer/pkg/core/common"
+	"fmt"
 	"github.com/spf13/cobra"
 )
 
@@ -26,5 +28,5 @@ func NewInstallGpuOptions() *InstallGpuOptions {
 
 func (o *InstallGpuOptions) AddFlags(cmd *cobra.Command) {
 	o.GpuOptions.AddFlags(cmd)
-	cmd.Flags().StringVar(&o.Cuda, "cuda", "", "The version of the CUDA driver, current supported versions are 12.4")
+	cmd.Flags().StringVar(&o.Cuda, "cuda", "", fmt.Sprintf("The version of the CUDA driver, current supported versions are %s", common.CurrentVerifiedCudaVersion))
 }

--- a/pkg/bootstrap/precheck/tasks.go
+++ b/pkg/bootstrap/precheck/tasks.go
@@ -652,9 +652,9 @@ func (t *RemoveWSLChattr) Execute(runtime connector.Runtime) error {
 	return nil
 }
 
-var ErrUnsupportedCudaVersion = errors.New("cuda version is too old, please install at least version 12.4, or you can uninstall it, REBOOT your machine, and let Olares install a new version for you.")
+var ErrUnsupportedCudaVersion = errors.New("unsupported cuda version, please uninstall it, REBOOT your machine, and try again")
 var ErrCudaInstalled = errors.New("cuda is installed")
-var supportedCudaVersions = []string{"12.4", "12.5", "12.6", "12.7", "12.8"}
+var supportedCudaVersions = []string{common.CurrentVerifiedCudaVersion}
 
 // CudaCheckTask checks the cuda version, if the current version is not supported, it will return an error
 // before executing the command `olares-cli gpu install`, we need to check the cuda version

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -28,7 +28,7 @@ const (
 	DefaultKubernetesVersion   = ""
 	DefaultKubeSphereVersion   = "v3.3.0"
 	DefaultTokenMaxAge         = 31536000
-	CurrentVerifiedCudaVersion = "12.4"
+	CurrentVerifiedCudaVersion = "12.9"
 )
 
 const (

--- a/pkg/phase/system/wsl.go
+++ b/pkg/phase/system/wsl.go
@@ -87,12 +87,7 @@ func (l *wslPhaseBuilder) build() []module.Module {
 	(&gpu.CheckWslGPU{}).Execute(l.runtime)
 	return l.base().
 		addModule(l.installContainerModule()...).
-		addModule(&images.PreloadImagesModule{
-			ManifestModule: manifest.ManifestModule{
-				Manifest: l.manifestMap,
-				BaseDir:  l.baseDir,
-			},
-		}).
+		addModule(&terminus.WriteReleaseFileModule{}).
 		addModule(gpuModuleBuilder(func() []module.Module {
 			return []module.Module{
 				// on wsl, only install container toolkit. cuda driver is already installed in windows
@@ -106,6 +101,12 @@ func (l *wslPhaseBuilder) build() []module.Module {
 			}
 
 		}).withGPU(l.runtime)...).
+		addModule(&images.PreloadImagesModule{
+			ManifestModule: manifest.ManifestModule{
+				Manifest: l.manifestMap,
+				BaseDir:  l.baseDir,
+			},
+		}).
 		addModule(terminusBoxModuleBuilder(func() []module.Module {
 			return []module.Module{
 				&daemon.InstallTerminusdBinaryModule{
@@ -116,6 +117,5 @@ func (l *wslPhaseBuilder) build() []module.Module {
 				},
 			}
 		}).inBox(l.runtime)...).
-		addModule(&terminus.PreparedModule{}).
-		addModule(&terminus.WriteReleaseFileModule{})
+		addModule(&terminus.PreparedModule{})
 }

--- a/pkg/pipelines/gpu_install.go
+++ b/pkg/pipelines/gpu_install.go
@@ -40,6 +40,7 @@ func InstallGpuDrivers(opt *options.InstallGpuOptions) error {
 					Manifest: manifestMap,
 					BaseDir:  runtime.Arg.BaseDir,
 				},
+				FailOnNoInstallation: true,
 			},
 			&gpu.InstallContainerToolkitModule{
 				ManifestModule: manifest.ManifestModule{
@@ -48,6 +49,7 @@ func InstallGpuDrivers(opt *options.InstallGpuOptions) error {
 				},
 			},
 			&gpu.RestartContainerdModule{},
+			&gpu.NodeLabelingModule{},
 		},
 		Runtime: runtime,
 	}

--- a/pkg/pipelines/gpu_upgrade.go
+++ b/pkg/pipelines/gpu_upgrade.go
@@ -46,6 +46,8 @@ func UpgradeGpuDrivers(opt *options.InstallGpuOptions) error {
 					Manifest: manifestMap,
 					BaseDir:  runtime.Arg.BaseDir,
 				},
+				FailOnNoInstallation:      true,
+				SkipNVMLCheckAfterInstall: true,
 			},
 			&gpu.InstallContainerToolkitModule{
 				ManifestModule: manifest.ManifestModule{


### PR DESCRIPTION
- upgrade CUDA to 12.9 (toolkit driver version 575)
- if the environment already has CUDA installed, the only version we tolerate is 12.9, rather than the current wide range
- during normal installation, if GPU card is found, after installing the Nvidia driver, its running status is checked by executing `nvidia-smi`, if it's not running properly, the installation process will exit in failure, instead of the current behavior of skipping other jobs silently
- during manually invoked GPU driver installation, i.e., `olares-cli gpu install/upgrade`, if no GPU card is found, the process will exit in failure. and if GPU card is found, `olares-cli gpu install` behaves like normal installation, while `olares-cli gpu upgrade` will proceed regardless of the status of the GPU driver, because `nvidia-smi` always fails to run if there's lib/driver version mismatch
- lift the modules related to GPU driver before the image preload module, to fail early, if any error related to the GPU driver
- lift the release file (`/etc/olares/release`) module before the modules related to GPU driver, to enable users to execute `olares-cli gpu` commands to fix issues, without specifying `--base-dir` and `--version`, if any error related to the GPU driver